### PR TITLE
refactor(common): introduce LoadableField pattern for batch retry/refresh

### DIFF
--- a/shared-ui/feature/home/impl/src/commonMain/kotlin/com/xbot/home/FeedPane.kt
+++ b/shared-ui/feature/home/impl/src/commonMain/kotlin/com/xbot/home/FeedPane.kt
@@ -155,7 +155,7 @@ internal fun FeedPane(
 
     viewModel.collectSideEffect { sideEffect ->
         when (sideEffect) {
-            is HomeScreenSideEffect.ShowErrorMessage -> {
+            is HomeScreenSideEffect.ShowLoadError -> {
                 SnackbarManager.showMessage(
                     title = sideEffect.error.localizedMessage(),
                     action = MessageAction(

--- a/shared-ui/feature/home/impl/src/commonMain/kotlin/com/xbot/home/SchedulePane.kt
+++ b/shared-ui/feature/home/impl/src/commonMain/kotlin/com/xbot/home/SchedulePane.kt
@@ -85,7 +85,7 @@ internal fun SchedulePane(
 
     viewModel.collectSideEffect { sideEffect ->
         when (sideEffect) {
-            is HomeScreenSideEffect.ShowErrorMessage -> {
+            is HomeScreenSideEffect.ShowLoadError -> {
                 SnackbarManager.showMessage(
                     title = sideEffect.error.localizedMessage(),
                     action = MessageAction(

--- a/shared-ui/feature/player/impl/src/commonMain/kotlin/com/xbot/player/PlayerScreen.kt
+++ b/shared-ui/feature/player/impl/src/commonMain/kotlin/com/xbot/player/PlayerScreen.kt
@@ -46,7 +46,7 @@ internal fun PlayerScreen(
 
     viewModel.collectSideEffect { sideEffect ->
         when (sideEffect) {
-            is PlayerScreenSideEffect.ShowErrorMessage -> {
+            is PlayerScreenSideEffect.ShowLoadError -> {
                 SnackbarManager.showMessage(
                     title = sideEffect.error.localizedMessage(),
                     action = MessageAction(

--- a/shared-ui/feature/search/impl/src/commonMain/kotlin/com/xbot/search/SearchFiltersPane.kt
+++ b/shared-ui/feature/search/impl/src/commonMain/kotlin/com/xbot/search/SearchFiltersPane.kt
@@ -91,7 +91,7 @@ internal fun SearchFilterPane(
 
     viewModel.collectSideEffect { sideEffect ->
         when (sideEffect) {
-            is SearchScreenSideEffect.ShowErrorMessage -> {
+            is SearchScreenSideEffect.ShowLoadError -> {
                 SnackbarManager.showMessage(
                     title = sideEffect.error.localizedMessage(),
                     action = MessageAction(

--- a/shared-ui/feature/search/impl/src/commonMain/kotlin/com/xbot/search/SearchResultPane.kt
+++ b/shared-ui/feature/search/impl/src/commonMain/kotlin/com/xbot/search/SearchResultPane.kt
@@ -85,7 +85,7 @@ internal fun SearchResultPane(
 
     viewModel.collectSideEffect { sideEffect ->
         when (sideEffect) {
-            is SearchScreenSideEffect.ShowErrorMessage -> {
+            is SearchScreenSideEffect.ShowLoadError -> {
                 SnackbarManager.showMessage(
                     title = sideEffect.error.localizedMessage(),
                     action = MessageAction(

--- a/shared-ui/feature/title/impl/src/commonMain/kotlin/com/xbot/title/TitleDetailsPane.kt
+++ b/shared-ui/feature/title/impl/src/commonMain/kotlin/com/xbot/title/TitleDetailsPane.kt
@@ -125,7 +125,7 @@ internal fun TitleDetailsPane(
 
     viewModel.collectSideEffect { sideEffect ->
         when (sideEffect) {
-            is TitleScreenSideEffect.ShowErrorMessage -> {
+            is TitleScreenSideEffect.ShowLoadError -> {
                 SnackbarManager.showMessage(
                     title = sideEffect.error.localizedMessage(),
                     action = MessageAction(

--- a/shared/common/src/commonMain/kotlin/com/xbot/common/AsyncLoad.kt
+++ b/shared/common/src/commonMain/kotlin/com/xbot/common/AsyncLoad.kt
@@ -5,21 +5,12 @@ import org.orbitmvi.orbit.syntax.Syntax
 
 suspend fun <T, E, S : Any, SE : Any> Syntax<S, SE>.asyncLoad(
     request: suspend () -> Either<E, T>,
-    onError: (suspend (E) -> Unit)? = null,
     reducer: S.(AsyncResult<E, T>) -> S
 ) {
     reduce { state.reducer(AsyncResult.Loading) }
 
     request().fold(
-        ifLeft = { error ->
-            if (onError != null) {
-                onError(error)
-            } else {
-                reduce { state.reducer(AsyncResult.Error(error)) }
-            }
-        },
-        ifRight = { data ->
-            reduce { state.reducer(AsyncResult.Success(data)) }
-        }
+        ifLeft = { error -> reduce { state.reducer(AsyncResult.Error(error)) } },
+        ifRight = { data -> reduce { state.reducer(AsyncResult.Success(data)) } }
     )
 }

--- a/shared/common/src/commonMain/kotlin/com/xbot/common/LoadableField.kt
+++ b/shared/common/src/commonMain/kotlin/com/xbot/common/LoadableField.kt
@@ -20,7 +20,11 @@ fun <S : Any> List<LoadableField<S>>.allSucceeded(state: S): Boolean =
 
 fun <S : Any> List<LoadableField<S>>.firstError(state: S): Throwable? =
     firstNotNullOfOrNull { field ->
-        (field.selector(state) as? AsyncResult.Error<*>)?.error as? Throwable
+        when (val error = (field.selector(state) as? AsyncResult.Error<*>)?.error) {
+            is Throwable -> error
+            null -> null
+            else -> RuntimeException("Unexpected error type: $error")
+        }
     }
 
 suspend fun <S : Any, SE : Any> Syntax<S, SE>.retryErrors(

--- a/shared/common/src/commonMain/kotlin/com/xbot/common/LoadableField.kt
+++ b/shared/common/src/commonMain/kotlin/com/xbot/common/LoadableField.kt
@@ -1,0 +1,43 @@
+package com.xbot.common
+
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.joinAll
+import org.orbitmvi.orbit.syntax.Syntax
+
+data class LoadableField<S : Any>(
+    val selector: (S) -> AsyncResult<*, *>,
+    val load: () -> Job
+)
+
+fun <S : Any> List<LoadableField<S>>.hasErrors(state: S): Boolean =
+    any { it.selector(state) is AsyncResult.Error }
+
+fun <S : Any> List<LoadableField<S>>.isLoading(state: S): Boolean =
+    any { it.selector(state) is AsyncResult.Loading }
+
+fun <S : Any> List<LoadableField<S>>.allSucceeded(state: S): Boolean =
+    all { it.selector(state) is AsyncResult.Success }
+
+fun <S : Any> List<LoadableField<S>>.firstError(state: S): Throwable? =
+    firstNotNullOfOrNull { field ->
+        (field.selector(state) as? AsyncResult.Error<*>)?.error as? Throwable
+    }
+
+suspend fun <S : Any, SE : Any> Syntax<S, SE>.retryErrors(
+    fields: List<LoadableField<S>>,
+    onBatchFailure: (suspend Syntax<S, SE>.() -> Unit)? = null
+) {
+    fields
+        .filter { it.selector(state) is AsyncResult.Error }
+        .map { it.load() }
+        .joinAll()
+    if (fields.hasErrors(state)) onBatchFailure?.invoke(this)
+}
+
+suspend fun <S : Any, SE : Any> Syntax<S, SE>.refreshAll(
+    fields: List<LoadableField<S>>,
+    onBatchFailure: (suspend Syntax<S, SE>.() -> Unit)? = null
+) {
+    fields.map { it.load() }.joinAll()
+    if (fields.hasErrors(state)) onBatchFailure?.invoke(this)
+}

--- a/shared/state/home/src/commonMain/kotlin/com/xbot/home/HomeScreenSideEffect.kt
+++ b/shared/state/home/src/commonMain/kotlin/com/xbot/home/HomeScreenSideEffect.kt
@@ -1,7 +1,7 @@
 package com.xbot.home
 
 sealed interface HomeScreenSideEffect {
-    data class ShowErrorMessage(
+    data class ShowLoadError(
         val error: Throwable,
         val onRetry: () -> Unit,
     ) : HomeScreenSideEffect

--- a/shared/state/home/src/commonMain/kotlin/com/xbot/home/HomeViewModel.kt
+++ b/shared/state/home/src/commonMain/kotlin/com/xbot/home/HomeViewModel.kt
@@ -6,7 +6,11 @@ import androidx.lifecycle.viewModelScope
 import androidx.paging.Pager
 import androidx.paging.PagingData
 import androidx.paging.cachedIn
+import com.xbot.common.LoadableField
 import com.xbot.common.asyncLoad
+import com.xbot.common.firstError
+import com.xbot.common.refreshAll
+import com.xbot.common.retryErrors
 import com.xbot.domain.models.AuthState
 import com.xbot.domain.models.Release
 import com.xbot.domain.usecase.GetAuthStateUseCase
@@ -23,6 +27,7 @@ import kotlinx.coroutines.flow.Flow
 import org.orbitmvi.orbit.Container
 import org.orbitmvi.orbit.ContainerHost
 import org.orbitmvi.orbit.annotation.OrbitExperimental
+import org.orbitmvi.orbit.syntax.Syntax
 import org.orbitmvi.orbit.viewmodel.container
 
 @OptIn(OrbitExperimental::class)
@@ -39,18 +44,28 @@ class HomeViewModel(
     private val savedStateHandle: SavedStateHandle,
 ) : ViewModel(), ContainerHost<HomeScreenState, HomeScreenSideEffect> {
 
+    private val loadableFields: List<LoadableField<HomeScreenState>> = listOf(
+        LoadableField(selector = { it.releasesFeed.bestNow }, load = ::loadBestReleasesInCurrentSeason),
+        LoadableField(selector = { it.releasesFeed.bestAllTime }, load = ::loadBestReleasesForAllTime),
+        LoadableField(selector = { it.releasesFeed.recommendedFranchises }, load = ::loadRecommendedFranchises),
+        LoadableField(selector = { it.releasesFeed.recommendedReleases }, load = ::loadRecommendedReleases),
+        LoadableField(selector = { it.releasesFeed.genres }, load = ::loadRecommendedGenres),
+        LoadableField(selector = { it.releasesFeed.scheduleNow }, load = ::loadScheduleForToday),
+        LoadableField(selector = { it.scheduleWeek.days }, load = ::loadScheduleWeek),
+    )
+
+    private val onLoadError: suspend Syntax<HomeScreenState, HomeScreenSideEffect>.() -> Unit = {
+        loadableFields.firstError(state)?.let { error ->
+            postSideEffect(HomeScreenSideEffect.ShowLoadError(error = error, onRetry = { retry() }))
+        }
+    }
+
     override val container: Container<HomeScreenState, HomeScreenSideEffect> = container(
         initialState = HomeScreenState(),
         savedStateHandle = savedStateHandle,
         serializer = HomeScreenState.serializer(),
     ) {
-        loadBestReleasesInCurrentSeason()
-        loadBestReleasesForAllTime()
-        loadRecommendedFranchises()
-        loadRecommendedReleases()
-        loadRecommendedGenres()
-        loadScheduleForToday()
-        loadScheduleWeek()
+        refreshAll(loadableFields, onBatchFailure = onLoadError)
         loadAuthState()
     }
 
@@ -64,70 +79,49 @@ class HomeViewModel(
     private fun loadBestReleasesInCurrentSeason(): Job = intent {
         asyncLoad(
             request = { getBestReleasesInCurrentSeason() },
-            onError = { error -> showErrorMessage(error) { loadBestReleasesInCurrentSeason() } },
-            reducer = {
-                copy(releasesFeed = state.releasesFeed.copy(bestNow = it))
-            }
+            reducer = { copy(releasesFeed = state.releasesFeed.copy(bestNow = it)) }
         )
     }
 
     private fun loadBestReleasesForAllTime(): Job = intent {
         asyncLoad(
             request = { getBestReleasesForAllTime() },
-            onError = { error -> showErrorMessage(error) { loadBestReleasesForAllTime() } },
-            reducer = {
-                copy(releasesFeed = state.releasesFeed.copy(bestAllTime = it))
-            }
+            reducer = { copy(releasesFeed = state.releasesFeed.copy(bestAllTime = it)) }
         )
     }
 
     private fun loadRecommendedFranchises(): Job = intent {
         asyncLoad(
             request = { getRecommendedFranchisesUseCase() },
-            onError = { error -> showErrorMessage(error) { loadRecommendedFranchises() } },
-            reducer = {
-                copy(releasesFeed = state.releasesFeed.copy(recommendedFranchises = it))
-            }
+            reducer = { copy(releasesFeed = state.releasesFeed.copy(recommendedFranchises = it)) }
         )
     }
 
     private fun loadRecommendedReleases(): Job = intent {
         asyncLoad(
             request = { getRecommendedReleases() },
-            onError = { error -> showErrorMessage(error) { loadRecommendedReleases() } },
-            reducer = {
-                copy(releasesFeed = state.releasesFeed.copy(recommendedReleases = it))
-            }
+            reducer = { copy(releasesFeed = state.releasesFeed.copy(recommendedReleases = it)) }
         )
     }
 
     private fun loadRecommendedGenres(): Job = intent {
         asyncLoad(
             request = { getRecommendedGenres() },
-            onError = { error -> showErrorMessage(error) { loadRecommendedGenres() } },
-            reducer = {
-                copy(releasesFeed = state.releasesFeed.copy(genres = it))
-            }
+            reducer = { copy(releasesFeed = state.releasesFeed.copy(genres = it)) }
         )
     }
 
     private fun loadScheduleForToday(): Job = intent {
         asyncLoad(
             request = { getScheduleForToday() },
-            onError = { error -> showErrorMessage(error) { loadScheduleForToday() } },
-            reducer = {
-                copy(releasesFeed = state.releasesFeed.copy(scheduleNow = it))
-            }
+            reducer = { copy(releasesFeed = state.releasesFeed.copy(scheduleNow = it)) }
         )
     }
 
     private fun loadScheduleWeek(): Job = intent {
         asyncLoad(
             request = { getScheduleWeek() },
-            onError = { error -> showErrorMessage(error) { loadScheduleWeek() } },
-            reducer = {
-                copy(scheduleWeek = state.scheduleWeek.copy(days = it))
-            }
+            reducer = { copy(scheduleWeek = state.scheduleWeek.copy(days = it)) }
         )
     }
 
@@ -146,18 +140,16 @@ class HomeViewModel(
         when (action) {
             is HomeScreenAction.Refresh -> refresh()
             is HomeScreenAction.UpdateBestType -> updateBestType(action.bestType)
-            is HomeScreenAction.ShowErrorMessage -> showErrorMessage(action.error, action.onRetry)
+            is HomeScreenAction.ShowErrorMessage -> showPagingError(action.error, action.onRetry)
         }
     }
 
-    private fun refresh() {
-        loadBestReleasesInCurrentSeason()
-        loadBestReleasesForAllTime()
-        loadRecommendedFranchises()
-        loadRecommendedReleases()
-        loadRecommendedGenres()
-        loadScheduleForToday()
-        loadScheduleWeek()
+    private fun retry(): Job = intent {
+        retryErrors(loadableFields, onBatchFailure = onLoadError)
+    }
+
+    private fun refresh(): Job = intent {
+        refreshAll(loadableFields, onBatchFailure = onLoadError)
         loadAuthState()
     }
 
@@ -165,7 +157,7 @@ class HomeViewModel(
         reduce { state.copy(currentBestType = bestType) }
     }
 
-    private fun showErrorMessage(error: Throwable, onRetry: () -> Unit): Job = intent {
-        postSideEffect(HomeScreenSideEffect.ShowErrorMessage(error, onRetry))
+    private fun showPagingError(error: Throwable, onRetry: () -> Unit): Job = intent {
+        postSideEffect(HomeScreenSideEffect.ShowLoadError(error = error, onRetry = onRetry))
     }
 }

--- a/shared/state/player/src/commonMain/kotlin/com/xbot/player/PlayerScreenSideEffect.kt
+++ b/shared/state/player/src/commonMain/kotlin/com/xbot/player/PlayerScreenSideEffect.kt
@@ -1,7 +1,7 @@
 package com.xbot.player
 
 sealed interface PlayerScreenSideEffect {
-    data class ShowErrorMessage(
+    data class ShowLoadError(
         val error: Throwable,
         val onRetry: () -> Unit,
     ) : PlayerScreenSideEffect

--- a/shared/state/player/src/commonMain/kotlin/com/xbot/player/PlayerViewModel.kt
+++ b/shared/state/player/src/commonMain/kotlin/com/xbot/player/PlayerViewModel.kt
@@ -2,6 +2,7 @@ package com.xbot.player
 
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
+import com.xbot.common.AsyncResult
 import com.xbot.common.asyncLoad
 import com.xbot.common.getOrNull
 import com.xbot.common.map
@@ -30,7 +31,6 @@ class PlayerViewModel(
     private fun loadTitleDetails(): Job = intent {
         asyncLoad(
             request = { getReleaseUseCase(releaseId) },
-            onError = { error -> showErrorMessage(error) { loadTitleDetails() } },
             reducer = { details ->
                 val episode = details.map { release ->
                     release.episodes.find { it.ordinal == initialEpisodeOrdinal.toFloat() }
@@ -52,6 +52,11 @@ class PlayerViewModel(
                 )
             }
         )
+
+        val error = (state.episodes as? AsyncResult.Error)?.error
+        if (error is Throwable) {
+            postSideEffect(PlayerScreenSideEffect.ShowLoadError(error = error, onRetry = { retry() }))
+        }
     }
 
     fun onAction(action: PlayerScreenAction) {
@@ -59,6 +64,10 @@ class PlayerViewModel(
             is PlayerScreenAction.OnEpisodeChange -> onEpisodeChange(action.episode)
             is PlayerScreenAction.OnQualityChange -> onQualityChange(action.quality)
         }
+    }
+
+    private fun retry() {
+        loadTitleDetails()
     }
 
     private fun onEpisodeChange(episode: Episode) = intent {
@@ -81,9 +90,5 @@ class PlayerViewModel(
         reduce {
             state.copy(quality = quality)
         }
-    }
-
-    private fun showErrorMessage(error: Throwable, onRetry: () -> Unit): Job = intent {
-        postSideEffect(PlayerScreenSideEffect.ShowErrorMessage(error, onRetry))
     }
 }

--- a/shared/state/player/src/commonMain/kotlin/com/xbot/player/PlayerViewModel.kt
+++ b/shared/state/player/src/commonMain/kotlin/com/xbot/player/PlayerViewModel.kt
@@ -2,17 +2,23 @@ package com.xbot.player
 
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
-import com.xbot.common.AsyncResult
+import com.xbot.common.LoadableField
 import com.xbot.common.asyncLoad
+import com.xbot.common.firstError
 import com.xbot.common.getOrNull
 import com.xbot.common.map
+import com.xbot.common.refreshAll
+import com.xbot.common.retryErrors
 import com.xbot.domain.models.Episode
 import com.xbot.domain.usecase.GetReleaseUseCase
 import kotlinx.coroutines.Job
 import org.orbitmvi.orbit.Container
 import org.orbitmvi.orbit.ContainerHost
+import org.orbitmvi.orbit.annotation.OrbitExperimental
+import org.orbitmvi.orbit.syntax.Syntax
 import org.orbitmvi.orbit.viewmodel.container
 
+@OptIn(OrbitExperimental::class)
 class PlayerViewModel(
     private val releaseId: String,
     private val initialEpisodeOrdinal: Int,
@@ -20,12 +26,22 @@ class PlayerViewModel(
     private val savedStateHandle: SavedStateHandle,
 ) : ViewModel(), ContainerHost<PlayerScreenState, PlayerScreenSideEffect> {
 
+    private val loadableFields: List<LoadableField<PlayerScreenState>> = listOf(
+        LoadableField(selector = { it.episodes }, load = ::loadTitleDetails),
+    )
+
+    private val onLoadError: suspend Syntax<PlayerScreenState, PlayerScreenSideEffect>.() -> Unit = {
+        loadableFields.firstError(state)?.let { error ->
+            postSideEffect(PlayerScreenSideEffect.ShowLoadError(error = error, onRetry = { retry() }))
+        }
+    }
+
     override val container: Container<PlayerScreenState, PlayerScreenSideEffect> = container(
         initialState = PlayerScreenState(),
         savedStateHandle = savedStateHandle,
         serializer = PlayerScreenState.serializer(),
     ) {
-        loadTitleDetails()
+        refreshAll(loadableFields, onBatchFailure = onLoadError)
     }
 
     private fun loadTitleDetails(): Job = intent {
@@ -52,11 +68,6 @@ class PlayerViewModel(
                 )
             }
         )
-
-        val error = (state.episodes as? AsyncResult.Error)?.error
-        if (error is Throwable) {
-            postSideEffect(PlayerScreenSideEffect.ShowLoadError(error = error, onRetry = { retry() }))
-        }
     }
 
     fun onAction(action: PlayerScreenAction) {
@@ -66,8 +77,8 @@ class PlayerViewModel(
         }
     }
 
-    private fun retry() {
-        loadTitleDetails()
+    private fun retry(): Job = intent {
+        retryErrors(loadableFields, onBatchFailure = onLoadError)
     }
 
     private fun onEpisodeChange(episode: Episode) = intent {

--- a/shared/state/search/src/commonMain/kotlin/com/xbot/search/SearchScreenAction.kt
+++ b/shared/state/search/src/commonMain/kotlin/com/xbot/search/SearchScreenAction.kt
@@ -18,9 +18,5 @@ sealed interface SearchScreenAction {
     data class UpdateSortingType(val sortingType: SortingType) : SearchScreenAction
     data class UpdateYearsRange(val years: IntRange) : SearchScreenAction
     data class ToggleAgeRating(val ageRating: AgeRating) : SearchScreenAction
-    data class ShowErrorMessage(
-        val error: Throwable,
-        val onRetry: () -> Unit,
-    ) : SearchScreenAction
     data object Refresh : SearchScreenAction
 }

--- a/shared/state/search/src/commonMain/kotlin/com/xbot/search/SearchScreenSideEffect.kt
+++ b/shared/state/search/src/commonMain/kotlin/com/xbot/search/SearchScreenSideEffect.kt
@@ -1,7 +1,7 @@
 package com.xbot.search
 
 sealed interface SearchScreenSideEffect {
-    data class ShowErrorMessage(
+    data class ShowLoadError(
         val error: Throwable,
         val onRetry: () -> Unit,
     ) : SearchScreenSideEffect

--- a/shared/state/search/src/commonMain/kotlin/com/xbot/search/SearchViewModel.kt
+++ b/shared/state/search/src/commonMain/kotlin/com/xbot/search/SearchViewModel.kt
@@ -5,8 +5,12 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import androidx.paging.PagingData
 import androidx.paging.cachedIn
+import com.xbot.common.LoadableField
 import com.xbot.common.asyncLoad
+import com.xbot.common.firstError
 import com.xbot.common.getOrElse
+import com.xbot.common.refreshAll
+import com.xbot.common.retryErrors
 import com.xbot.domain.models.Genre
 import com.xbot.domain.models.Release
 import com.xbot.domain.models.enums.AgeRating
@@ -36,9 +40,10 @@ import kotlinx.coroutines.flow.map
 import org.orbitmvi.orbit.Container
 import org.orbitmvi.orbit.ContainerHost
 import org.orbitmvi.orbit.annotation.OrbitExperimental
+import org.orbitmvi.orbit.syntax.Syntax
 import org.orbitmvi.orbit.viewmodel.container
 
-@OptIn(ExperimentalCoroutinesApi::class)
+@OptIn(ExperimentalCoroutinesApi::class, OrbitExperimental::class)
 class SearchViewModel(
     private val getCatalogReleasesPager: GetCatalogReleasesPagerUseCase,
     private val getCatalogAgeRatings: GetCatalogAgeRatingsUseCase,
@@ -52,19 +57,29 @@ class SearchViewModel(
     private val savedStateHandle: SavedStateHandle,
 ) : ViewModel(), ContainerHost<SearchScreenState, SearchScreenSideEffect> {
 
+    private val loadableFields: List<LoadableField<SearchScreenState>> = listOf(
+        LoadableField(selector = { it.genres }, load = ::loadGenres),
+        LoadableField(selector = { it.releaseTypes }, load = ::loadReleaseTypes),
+        LoadableField(selector = { it.publishStatuses }, load = ::loadPublishStatuses),
+        LoadableField(selector = { it.productionStatuses }, load = ::loadProductionStatuses),
+        LoadableField(selector = { it.sortingTypes }, load = ::loadSortingTypes),
+        LoadableField(selector = { it.seasons }, load = ::loadSeasons),
+        LoadableField(selector = { it.ageRatings }, load = ::loadAgeRatings),
+        LoadableField(selector = { it.years }, load = ::loadYears),
+    )
+
+    private val onLoadError: suspend Syntax<SearchScreenState, SearchScreenSideEffect>.() -> Unit = {
+        loadableFields.firstError(state)?.let { error ->
+            postSideEffect(SearchScreenSideEffect.ShowLoadError(error = error, onRetry = { retry() }))
+        }
+    }
+
     override val container: Container<SearchScreenState, SearchScreenSideEffect> = container(
         initialState = SearchScreenState(),
         savedStateHandle = savedStateHandle,
         serializer = SearchScreenState.serializer()
     ) {
-        loadGenres()
-        loadReleaseTypes()
-        loadPublishStatuses()
-        loadProductionStatuses()
-        loadSortingTypes()
-        loadSeasons()
-        loadAgeRatings()
-        loadYears()
+        refreshAll(loadableFields, onBatchFailure = onLoadError)
     }
 
     // TODO: Move inside SearchScreenState once Paging 3.5.0 stable ships asState()
@@ -81,88 +96,58 @@ class SearchViewModel(
         ).flow
     }.cachedIn(viewModelScope)
 
-    @OptIn(OrbitExperimental::class)
     private fun loadGenres(): Job = intent {
         asyncLoad(
             request = { getCatalogGenres() },
-            onError = { error -> showErrorMessage(error) { loadGenres() } },
-            reducer = {
-                copy(genres = it)
-            }
+            reducer = { copy(genres = it) }
         )
     }
 
-    @OptIn(OrbitExperimental::class)
     private fun loadReleaseTypes(): Job = intent {
         asyncLoad(
             request = { getCatalogReleaseTypes() },
-            onError = { error -> showErrorMessage(error) { loadReleaseTypes() } },
-            reducer = {
-                copy(releaseTypes = it)
-            }
+            reducer = { copy(releaseTypes = it) }
         )
     }
 
-    @OptIn(OrbitExperimental::class)
     private fun loadPublishStatuses(): Job = intent {
         asyncLoad(
             request = { getCatalogPublishStatuses() },
-            onError = { error -> showErrorMessage(error) { loadPublishStatuses() } },
-            reducer = {
-                copy(publishStatuses = it)
-            }
+            reducer = { copy(publishStatuses = it) }
         )
     }
 
-    @OptIn(OrbitExperimental::class)
     private fun loadProductionStatuses(): Job = intent {
         asyncLoad(
             request = { getCatalogProductionStatuses() },
-            onError = { error -> showErrorMessage(error) { loadProductionStatuses() } },
-            reducer = {
-                copy(productionStatuses = it)
-            }
+            reducer = { copy(productionStatuses = it) }
         )
     }
 
-    @OptIn(OrbitExperimental::class)
     private fun loadSortingTypes(): Job = intent {
         asyncLoad(
             request = { getCatalogSortingTypes() },
-            onError = { error -> showErrorMessage(error) { loadSortingTypes() } },
-            reducer = {
-                copy(sortingTypes = it)
-            }
+            reducer = { copy(sortingTypes = it) }
         )
     }
 
-    @OptIn(OrbitExperimental::class)
     private fun loadSeasons(): Job = intent {
         asyncLoad(
             request = { getCatalogSeasons() },
-            onError = { error -> showErrorMessage(error) { loadSeasons() } },
-            reducer = {
-                copy(seasons = it)
-            }
+            reducer = { copy(seasons = it) }
         )
     }
 
-    @OptIn(OrbitExperimental::class)
     private fun loadAgeRatings(): Job = intent {
         asyncLoad(
             request = { getCatalogAgeRatings() },
-            onError = { error -> showErrorMessage(error) { loadAgeRatings() } },
-            reducer = {
-                copy(ageRatings = it)
-            }
+            reducer = { copy(ageRatings = it) }
         )
     }
 
-    @OptIn(OrbitExperimental::class)
     private fun loadYears(): Job = intent {
         asyncLoad(
             request = { getCatalogYears() },
-            onError = { error -> showErrorMessage(error) { loadYears() } },
             reducer = {
                 copy(
                     years = it,
@@ -183,9 +168,16 @@ class SearchViewModel(
             is SearchScreenAction.UpdateSortingType -> updateSortingType(action.sortingType)
             is SearchScreenAction.UpdateYearsRange -> updateYearsRange(action.years)
             is SearchScreenAction.ToggleAgeRating -> toggleAgeRating(action.ageRating)
-            is SearchScreenAction.ShowErrorMessage -> showErrorMessage(action.error, action.onRetry)
             is SearchScreenAction.Refresh -> refresh()
         }
+    }
+
+    private fun retry(): Job = intent {
+        retryErrors(loadableFields, onBatchFailure = onLoadError)
+    }
+
+    private fun refresh(): Job = intent {
+        refreshAll(loadableFields, onBatchFailure = onLoadError)
     }
 
     private fun updateQuery(query: String) = intent {
@@ -222,21 +214,6 @@ class SearchViewModel(
 
     private fun toggleAgeRating(ageRating: AgeRating) = intent {
         reduce { state.copy(filters = state.filters.copy(selectedAgeRatings = state.filters.selectedAgeRatings.toggle(ageRating))) }
-    }
-
-    private fun showErrorMessage(error: Throwable, onRetry: () -> Unit) = intent {
-        postSideEffect(SearchScreenSideEffect.ShowErrorMessage(error, onRetry))
-    }
-
-    private fun refresh() {
-        loadGenres()
-        loadReleaseTypes()
-        loadPublishStatuses()
-        loadProductionStatuses()
-        loadSortingTypes()
-        loadSeasons()
-        loadAgeRatings()
-        loadYears()
     }
 
     private fun <T> Set<T>.toggle(item: T) = if (item in this) this - item else this + item

--- a/shared/state/title/src/commonMain/kotlin/com/xbot/title/TitleScreenSideEffect.kt
+++ b/shared/state/title/src/commonMain/kotlin/com/xbot/title/TitleScreenSideEffect.kt
@@ -1,7 +1,7 @@
 package com.xbot.title
 
 sealed interface TitleScreenSideEffect {
-    data class ShowErrorMessage(
+    data class ShowLoadError(
         val error: Throwable,
         val onRetry: () -> Unit,
     ) : TitleScreenSideEffect

--- a/shared/state/title/src/commonMain/kotlin/com/xbot/title/TitleViewModel.kt
+++ b/shared/state/title/src/commonMain/kotlin/com/xbot/title/TitleViewModel.kt
@@ -1,16 +1,23 @@
 package com.xbot.title
 
 import androidx.lifecycle.ViewModel
+import com.xbot.common.LoadableField
 import com.xbot.common.asyncLoad
+import com.xbot.common.firstError
 import com.xbot.common.getOrNull
+import com.xbot.common.refreshAll
+import com.xbot.common.retryErrors
 import com.xbot.domain.models.Release
 import com.xbot.domain.usecase.GetFranchiseReleasesUseCase
 import com.xbot.domain.usecase.GetReleaseUseCase
 import kotlinx.coroutines.Job
 import org.orbitmvi.orbit.Container
 import org.orbitmvi.orbit.ContainerHost
+import org.orbitmvi.orbit.annotation.OrbitExperimental
+import org.orbitmvi.orbit.syntax.Syntax
 import org.orbitmvi.orbit.viewmodel.container
 
+@OptIn(OrbitExperimental::class)
 class TitleViewModel(
     private val aliasOrId: String,
     private val initialRelease: Release? = null,
@@ -18,17 +25,26 @@ class TitleViewModel(
     private val getFranchiseReleases: GetFranchiseReleasesUseCase,
 ) : ViewModel(), ContainerHost<TitleScreenState, TitleScreenSideEffect> {
 
+    private val loadableFields: List<LoadableField<TitleScreenState>> = listOf(
+        LoadableField(selector = { it.details }, load = ::loadDetails),
+        LoadableField(selector = { it.relatedReleases }, load = ::loadRelatedReleases),
+    )
+
+    private val onLoadError: suspend Syntax<TitleScreenState, TitleScreenSideEffect>.() -> Unit = {
+        loadableFields.firstError(state)?.let { error ->
+            postSideEffect(TitleScreenSideEffect.ShowLoadError(error = error, onRetry = { retry() }))
+        }
+    }
+
     override val container: Container<TitleScreenState, TitleScreenSideEffect> = container(
         initialState = TitleScreenState(initialRelease = initialRelease)
     ) {
-        loadDetails()
-        loadRelatedReleases()
+        refreshAll(loadableFields, onBatchFailure = onLoadError)
     }
 
     private fun loadDetails(): Job = intent {
         asyncLoad(
             request = { getRelease(aliasOrId) },
-            onError = { error -> showError(error) { loadDetails() } },
             reducer = {
                 copy(
                     initialRelease = it.getOrNull()?.release ?: initialRelease,
@@ -41,10 +57,7 @@ class TitleViewModel(
     private fun loadRelatedReleases(): Job = intent {
         asyncLoad(
             request = { getFranchiseReleases(aliasOrId) },
-            onError = { error -> showError(error) { loadRelatedReleases() } },
-            reducer = {
-                copy(relatedReleases = it)
-            }
+            reducer = { copy(relatedReleases = it) }
         )
     }
 
@@ -54,12 +67,11 @@ class TitleViewModel(
         }
     }
 
-    private fun refresh() {
-        loadDetails()
-        loadRelatedReleases()
+    private fun retry(): Job = intent {
+        retryErrors(loadableFields, onBatchFailure = onLoadError)
     }
 
-    private fun showError(error: Throwable, retryAction: () -> Unit) = intent {
-        postSideEffect(TitleScreenSideEffect.ShowErrorMessage(error, retryAction))
+    private fun refresh(): Job = intent {
+        refreshAll(loadableFields, onBatchFailure = onLoadError)
     }
 }


### PR DESCRIPTION
## Summary
- Introduce `LoadableField<S>` abstraction in `shared/common` that pairs a state selector with a loader, enabling batch operations over groups of async fields
- Add `retryErrors()` (reloads only failed fields) and `refreshAll()` (reloads all fields) as Orbit `Syntax` extensions with `onBatchFailure` callback
- Simplify `asyncLoad` by removing `onError` parameter — errors are now always stored in state, fixing the bug where fields stayed stuck at `Loading` forever
- Unify all error side effects under `ShowLoadError(error, onRetry)` across Home, Search, Title, and Player ViewModels
- Remove dead `SearchScreenAction.ShowErrorMessage` (Search paging retries directly in UI)

## Test plan
- [ ] Verify batch error: simulate poor network — only one snackbar should appear regardless of how many fields fail
- [ ] Verify retry: tap snackbar retry — only `Error` fields should reload, `Success` fields stay untouched
- [ ] Verify refresh: pull-to-refresh reloads all fields regardless of state
- [ ] Verify paging errors still work independently in FeedPane and SearchResultPane
- [ ] Verify process death restoration: kill app, restore — all transient fields should reload

🤖 Generated with [Claude Code](https://claude.com/claude-code)