### PR TITLE
feat(network): fault-tolerant HTTP with typed errors and connectivity awareness

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -125,6 +125,7 @@ coil-compose = { group = "io.coil-kt.coil3", name = "coil-compose", version.ref 
 coil-network-ktor = { group = "io.coil-kt.coil3", name = "coil-network-ktor3", version.ref = "coil" }
 arrow-core = { group = "io.arrow-kt", name = "arrow-core", version.ref = "arrow" }
 arrow-coroutines = { group = "io.arrow-kt", name = "arrow-fx-coroutines", version.ref = "arrow" }
+arrow-resilience = { group = "io.arrow-kt", name = "arrow-resilience", version.ref = "arrow" }
 eygraber-uri = { group = "com.eygraber", name = "uri-kmp", version.ref = "eygraber-uri" }
 slf4j = { group = "org.slf4j", name = "slf4j-simple", version = "2.0.17" }
 material-motion-compose-core = { group = "io.github.fornewid", name = "material-motion-compose-core", version.ref = "material-motion-compose" }

--- a/shared-ui/formatters/src/commonMain/kotlin/com/xbot/localization/DomainErrorExt.kt
+++ b/shared-ui/formatters/src/commonMain/kotlin/com/xbot/localization/DomainErrorExt.kt
@@ -4,13 +4,17 @@ import com.xbot.domain.models.DomainError
 import com.xbot.resources.Res
 import com.xbot.resources.error_connection
 import com.xbot.resources.error_http
+import com.xbot.resources.error_no_connection
 import com.xbot.resources.error_serialization
+import com.xbot.resources.error_timeout
 import com.xbot.resources.error_unknown
 
 fun Throwable.localizedMessage(): UiText {
     return when (this) {
         is DomainError.HttpError -> UiText.Text(Res.string.error_http, this.code)
         is DomainError.ConnectionError -> UiText.Text(Res.string.error_connection)
+        is DomainError.Timeout -> UiText.Text(Res.string.error_timeout)
+        DomainError.NoConnection -> UiText.Text(Res.string.error_no_connection)
         is DomainError.SerializationError -> {
             val message = findRecursiveMessage(this) ?: "Empty message"
             UiText.Text(Res.string.error_serialization, message)

--- a/shared-ui/resource/src/commonMain/composeResources/values-ru/strings.xml
+++ b/shared-ui/resource/src/commonMain/composeResources/values-ru/strings.xml
@@ -65,6 +65,8 @@
     <string name="error_serialization">Ошибка обработки данных: %1$s</string>
     <string name="error_http">Ошибка сервера (%1$d)</string>
     <string name="error_unknown">Неизвестная ошибка %1$s по причине %2$s: %3$s</string>
+    <string name="error_timeout">Превышено время ожидания</string>
+    <string name="error_no_connection">Нет подключения к интернету</string>
 
     <!-- Типы релизов -->
     <string name="release_type_tv">ТВ</string>

--- a/shared-ui/resource/src/commonMain/composeResources/values/strings.xml
+++ b/shared-ui/resource/src/commonMain/composeResources/values/strings.xml
@@ -65,6 +65,8 @@
     <string name="error_serialization">Data processing error: %1$s</string>
     <string name="error_http">Server error (%1$d)</string>
     <string name="error_unknown">Unknown error %1$s caused by %2$s: %3$s</string>
+    <string name="error_timeout">Request timed out</string>
+    <string name="error_no_connection">You\'re offline</string>
 
     <!-- Типы релизов -->
     <string name="release_type_tv">TV</string>

--- a/shared/common/src/commonMain/kotlin/com/xbot/common/AsyncResult.kt
+++ b/shared/common/src/commonMain/kotlin/com/xbot/common/AsyncResult.kt
@@ -1,5 +1,18 @@
 package com.xbot.common
 
+import arrow.core.Either
+
+/**
+ * Tri-state UI container: `Loading` while an async operation is in flight, `Success`
+ * when it completed with a value, `Error` with a typed failure.
+ *
+ * This is intentionally distinct from Arrow's [Either]. Arrow models the outcome of
+ * a computation (success/failure) — the "not yet" case is a UI concern that Arrow
+ * does not express, and the candidates that come close (`Option<Either<E, T>>`,
+ * `Ior`, `Either<AsyncFailure, T>`) all read worse at the use sites that drive
+ * Compose placeholders. Keep the split clean: Arrow at the repository boundary,
+ * [AsyncResult] in UI state — bridged by [toAsyncResult].
+ */
 sealed interface AsyncResult<out E, out T> {
     data class Success<out T>(val data: T) : AsyncResult<Nothing, T>
     data class Error<out E>(val error: E) : AsyncResult<E, Nothing>
@@ -14,4 +27,52 @@ inline fun <E, T, R> AsyncResult<E, T>.map(transform: (T) -> R): AsyncResult<E, 
     is AsyncResult.Success -> AsyncResult.Success(transform(data))
     is AsyncResult.Error -> this
     is AsyncResult.Loading -> this
+}
+
+/**
+ * Bridge an Arrow computation outcome into a UI-ready [AsyncResult].
+ *
+ * The `Loading` state is never produced here — it's strictly a pre-completion marker
+ * that the caller is expected to have set *before* awaiting the [Either]. Use this
+ * at the end of the await step (typically in an Orbit `reduce {}`).
+ */
+fun <E, T> Either<E, T>.toAsyncResult(): AsyncResult<E, T> = fold(
+    ifLeft = { AsyncResult.Error(it) },
+    ifRight = { AsyncResult.Success(it) },
+)
+
+/**
+ * Dispatch on the three states in a single expression — useful for Compose render
+ * code that needs a value per branch.
+ */
+inline fun <E, T, R> AsyncResult<E, T>.fold(
+    onLoading: () -> R,
+    onError: (E) -> R,
+    onSuccess: (T) -> R,
+): R = when (this) {
+    AsyncResult.Loading -> onLoading()
+    is AsyncResult.Error -> onError(error)
+    is AsyncResult.Success -> onSuccess(data)
+}
+
+/**
+ * Run [action] only on [AsyncResult.Success], pass the receiver through unchanged —
+ * chains cleanly with [onError] / [onLoading].
+ */
+inline fun <E, T> AsyncResult<E, T>.onSuccess(action: (T) -> Unit): AsyncResult<E, T> = also {
+    if (this is AsyncResult.Success) action(data)
+}
+
+/**
+ * Run [action] only on [AsyncResult.Error].
+ */
+inline fun <E, T> AsyncResult<E, T>.onError(action: (E) -> Unit): AsyncResult<E, T> = also {
+    if (this is AsyncResult.Error) action(error)
+}
+
+/**
+ * Run [action] only on [AsyncResult.Loading].
+ */
+inline fun <E, T> AsyncResult<E, T>.onLoading(action: () -> Unit): AsyncResult<E, T> = also {
+    if (this is AsyncResult.Loading) action()
 }

--- a/shared/core/data/impl/src/commonMain/kotlin/com/xbot/data/datasource/CommonPagingSource.kt
+++ b/shared/core/data/impl/src/commonMain/kotlin/com/xbot/data/datasource/CommonPagingSource.kt
@@ -25,10 +25,24 @@ import kotlin.math.max
  * a nullable field, bad enum parse, etc.) would otherwise escape this `fold`. Wrap
  * the body so non-cancellation throws become `LoadResult.Error`, and rethrow
  * `CancellationException` explicitly so structured concurrency still works.
+ *
+ * **Page-size coupling contract:** [pageSize] MUST equal the `PagingConfig.pageSize`
+ * of the enclosing [androidx.paging.Pager]. The key arithmetic relies on the
+ * invariant that `loadSize` is always a multiple of [pageSize] — if the `Pager`
+ * uses a different pageSize, `itemsBefore` (`pageIndex * pageSize`) and the server
+ * offset `(page-1) * loadSize` drift apart and you get gaps or duplicate items.
+ * The `init` block asserts `pageSize > 0`; call-site alignment is documented, not
+ * statically enforceable.
  */
 internal class CommonPagingSource<T : Any>(
+    private val pageSize: Int = DEFAULT_PAGE_SIZE,
     private val loadPage: suspend (page: Int, limit: Int) -> Either<DomainError, PaginatedResponse<T>>,
 ) : PagingSource<Int, T>() {
+
+    init {
+        require(pageSize > 0) { "pageSize must be > 0, got $pageSize" }
+    }
+
     override suspend fun load(params: LoadParams<Int>): LoadResult<Int, T> {
         val pageIndex = params.key ?: FIRST_PAGE_INDEX
         val loadSize = params.loadSize
@@ -38,18 +52,17 @@ internal class CommonPagingSource<T : Any>(
                 ifRight = { page ->
                     val newCount = page.items.size
                     val total = page.total
-                    val itemsBefore = pageIndex * NETWORK_PAGE_SIZE
+                    val itemsBefore = pageIndex * pageSize
                     val itemsAfter = max(total - (itemsBefore + newCount), 0)
 
                     val prevKey = if (pageIndex == FIRST_PAGE_INDEX) null else pageIndex - 1
-                    // `loadSize / NETWORK_PAGE_SIZE` goes to 0 if the Pager is configured
-                    // with a pageSize smaller than NETWORK_PAGE_SIZE — then nextKey would
-                    // stay equal to pageIndex and the source would loop forever requesting
-                    // the same page. `coerceAtLeast(1)` guarantees forward progress.
+                    // Guard against a Pager misconfigured with `loadSize < pageSize`
+                    // (would divide to 0 and loop on the same page). With the contract
+                    // honoured this just evaluates to `loadSize / pageSize`.
                     val nextKey = if (itemsAfter == 0) {
                         null
                     } else {
-                        pageIndex + (loadSize / NETWORK_PAGE_SIZE).coerceAtLeast(1)
+                        pageIndex + (loadSize / pageSize).coerceAtLeast(1)
                     }
 
                     LoadResult.Page(
@@ -70,8 +83,7 @@ internal class CommonPagingSource<T : Any>(
 
     override fun getRefreshKey(state: PagingState<Int, T>): Int? {
         val anchorPosition = state.anchorPosition ?: return null
-        val pageIndex = anchorPosition / NETWORK_PAGE_SIZE
-        return pageIndex
+        return anchorPosition / pageSize
     }
 
     override val jumpingSupported: Boolean = true
@@ -82,7 +94,8 @@ internal class CommonPagingSource<T : Any>(
     )
 
     companion object {
-        const val NETWORK_PAGE_SIZE = 20
+        /** Default page size used when callers don't override. Matches the API's canonical page window. */
+        const val DEFAULT_PAGE_SIZE = 20
         private const val FIRST_PAGE_INDEX = 0
     }
 }

--- a/shared/core/data/impl/src/commonMain/kotlin/com/xbot/data/datasource/CommonPagingSource.kt
+++ b/shared/core/data/impl/src/commonMain/kotlin/com/xbot/data/datasource/CommonPagingSource.kt
@@ -4,6 +4,7 @@ import androidx.paging.PagingSource
 import androidx.paging.PagingState
 import arrow.core.Either
 import com.xbot.domain.models.DomainError
+import kotlinx.coroutines.CancellationException
 import kotlin.math.max
 
 /**
@@ -17,9 +18,13 @@ import kotlin.math.max
  * `(loadState.refresh as? LoadState.Error)?.error`) get the typed error directly and
  * can downcast for tailored messaging.
  *
- * Cancellation: [loadPage] is a suspending Arrow-returning function — its producer
+ * Cancellation & defensive catch: the [loadPage] producer
  * (`ResilientHttpRequester.singleAttempt`) already rethrows `CancellationException`,
- * so we don't need a defensive `try/catch` here.
+ * but the lambda runs a downstream DTO→domain mapping step (`.map { dto.toDomain() }`)
+ * and `Either.map` does NOT catch throws. A runtime exception inside a mapper (NPE on
+ * a nullable field, bad enum parse, etc.) would otherwise escape this `fold`. Wrap
+ * the body so non-cancellation throws become `LoadResult.Error`, and rethrow
+ * `CancellationException` explicitly so structured concurrency still works.
  */
 internal class CommonPagingSource<T : Any>(
     private val loadPage: suspend (page: Int, limit: Int) -> Either<DomainError, PaginatedResponse<T>>,
@@ -27,26 +32,40 @@ internal class CommonPagingSource<T : Any>(
     override suspend fun load(params: LoadParams<Int>): LoadResult<Int, T> {
         val pageIndex = params.key ?: FIRST_PAGE_INDEX
         val loadSize = params.loadSize
-        return loadPage(pageIndex + 1, loadSize).fold(
-            ifLeft = { error -> LoadResult.Error(error) },
-            ifRight = { page ->
-                val newCount = page.items.size
-                val total = page.total
-                val itemsBefore = pageIndex * NETWORK_PAGE_SIZE
-                val itemsAfter = max(total - (itemsBefore + newCount), 0)
+        return try {
+            loadPage(pageIndex + 1, loadSize).fold(
+                ifLeft = { error -> LoadResult.Error(error) },
+                ifRight = { page ->
+                    val newCount = page.items.size
+                    val total = page.total
+                    val itemsBefore = pageIndex * NETWORK_PAGE_SIZE
+                    val itemsAfter = max(total - (itemsBefore + newCount), 0)
 
-                val prevKey = if (pageIndex == FIRST_PAGE_INDEX) null else pageIndex - 1
-                val nextKey = if (itemsAfter == 0) null else pageIndex + (loadSize / NETWORK_PAGE_SIZE)
+                    val prevKey = if (pageIndex == FIRST_PAGE_INDEX) null else pageIndex - 1
+                    // `loadSize / NETWORK_PAGE_SIZE` goes to 0 if the Pager is configured
+                    // with a pageSize smaller than NETWORK_PAGE_SIZE — then nextKey would
+                    // stay equal to pageIndex and the source would loop forever requesting
+                    // the same page. `coerceAtLeast(1)` guarantees forward progress.
+                    val nextKey = if (itemsAfter == 0) {
+                        null
+                    } else {
+                        pageIndex + (loadSize / NETWORK_PAGE_SIZE).coerceAtLeast(1)
+                    }
 
-                LoadResult.Page(
-                    data = page.items,
-                    prevKey = prevKey,
-                    nextKey = nextKey,
-                    itemsBefore = itemsBefore,
-                    itemsAfter = itemsAfter,
-                )
-            },
-        )
+                    LoadResult.Page(
+                        data = page.items,
+                        prevKey = prevKey,
+                        nextKey = nextKey,
+                        itemsBefore = itemsBefore,
+                        itemsAfter = itemsAfter,
+                    )
+                },
+            )
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            LoadResult.Error(e)
+        }
     }
 
     override fun getRefreshKey(state: PagingState<Int, T>): Int? {

--- a/shared/core/data/impl/src/commonMain/kotlin/com/xbot/data/datasource/CommonPagingSource.kt
+++ b/shared/core/data/impl/src/commonMain/kotlin/com/xbot/data/datasource/CommonPagingSource.kt
@@ -2,35 +2,51 @@ package com.xbot.data.datasource
 
 import androidx.paging.PagingSource
 import androidx.paging.PagingState
+import arrow.core.Either
+import com.xbot.domain.models.DomainError
 import kotlin.math.max
 
+/**
+ * Paging3 bridge that speaks Arrow [Either] internally and only crosses into Paging's
+ * `Throwable`-based contract at the very last step.
+ *
+ * [loadPage] returns `Either<DomainError, PaginatedResponse<T>>` so repositories never
+ * have to `throw` to signal failure; we [fold][Either.fold] at the [LoadResult]
+ * boundary. Because [DomainError] extends [Exception], `LoadResult.Error(domainError)`
+ * satisfies Paging's contract without an artificial wrapper — UI readers (e.g.,
+ * `(loadState.refresh as? LoadState.Error)?.error`) get the typed error directly and
+ * can downcast for tailored messaging.
+ *
+ * Cancellation: [loadPage] is a suspending Arrow-returning function — its producer
+ * (`ResilientHttpRequester.singleAttempt`) already rethrows `CancellationException`,
+ * so we don't need a defensive `try/catch` here.
+ */
 internal class CommonPagingSource<T : Any>(
-    private val loadPage: suspend (page: Int, limit: Int) -> PaginatedResponse<T>,
+    private val loadPage: suspend (page: Int, limit: Int) -> Either<DomainError, PaginatedResponse<T>>,
 ) : PagingSource<Int, T>() {
     override suspend fun load(params: LoadParams<Int>): LoadResult<Int, T> {
         val pageIndex = params.key ?: FIRST_PAGE_INDEX
         val loadSize = params.loadSize
-        return try {
-            val page = loadPage(pageIndex + 1, loadSize)
+        return loadPage(pageIndex + 1, loadSize).fold(
+            ifLeft = { error -> LoadResult.Error(error) },
+            ifRight = { page ->
+                val newCount = page.items.size
+                val total = page.total
+                val itemsBefore = pageIndex * NETWORK_PAGE_SIZE
+                val itemsAfter = max(total - (itemsBefore + newCount), 0)
 
-            val newCount = page.items.size
-            val total = page.total
-            val itemsBefore = pageIndex * NETWORK_PAGE_SIZE
-            val itemsAfter = max(total - (itemsBefore + newCount), 0)
+                val prevKey = if (pageIndex == FIRST_PAGE_INDEX) null else pageIndex - 1
+                val nextKey = if (itemsAfter == 0) null else pageIndex + (loadSize / NETWORK_PAGE_SIZE)
 
-            val prevKey = if (pageIndex == FIRST_PAGE_INDEX) null else pageIndex - 1
-            val nextKey = if (itemsAfter == 0) null else pageIndex + (params.loadSize / NETWORK_PAGE_SIZE)
-
-            LoadResult.Page(
-                data = page.items,
-                prevKey = prevKey,
-                nextKey = nextKey,
-                itemsBefore = itemsBefore,
-                itemsAfter = itemsAfter,
-            )
-        } catch (e: Exception) {
-            LoadResult.Error(e)
-        }
+                LoadResult.Page(
+                    data = page.items,
+                    prevKey = prevKey,
+                    nextKey = nextKey,
+                    itemsBefore = itemsBefore,
+                    itemsAfter = itemsAfter,
+                )
+            },
+        )
     }
 
     override fun getRefreshKey(state: PagingState<Int, T>): Int? {

--- a/shared/core/data/impl/src/commonMain/kotlin/com/xbot/data/mapper/Mapper.kt
+++ b/shared/core/data/impl/src/commonMain/kotlin/com/xbot/data/mapper/Mapper.kt
@@ -13,7 +13,6 @@ import com.xbot.domain.models.ScheduleType
 import com.xbot.domain.models.User
 import com.xbot.domain.models.enums.AvailabilityStatus
 import com.xbot.network.Constants
-import com.xbot.network.client.NetworkError
 import com.xbot.network.models.dto.EpisodeDto
 import com.xbot.network.models.dto.FranchiseDto
 import com.xbot.network.models.dto.GenreDto
@@ -195,10 +194,3 @@ internal fun FranchiseDto.toDomain() = Franchise(
     },
     franchiseReleases = franchiseReleases?.map { it.release.toDomain() },
 )
-
-internal fun NetworkError.toDomain(): DomainError = when (this) {
-    is NetworkError.HttpError -> DomainError.HttpError(this.code, this.message)
-    is NetworkError.ConnectionError -> DomainError.ConnectionError(this.cause)
-    is NetworkError.SerializationError -> DomainError.SerializationError(this.cause)
-    is NetworkError.UnknownError -> DomainError.UnknownError(this.cause)
-}

--- a/shared/core/data/impl/src/commonMain/kotlin/com/xbot/data/repository/DefaultAuthRepository.kt
+++ b/shared/core/data/impl/src/commonMain/kotlin/com/xbot/data/repository/DefaultAuthRepository.kt
@@ -7,7 +7,6 @@ import com.xbot.data.mapper.toDto
 import com.xbot.domain.models.DomainError
 import com.xbot.domain.models.enums.SocialType
 import com.xbot.network.api.AuthApi
-import com.xbot.network.client.NetworkError
 import com.xbot.network.client.SessionStorage
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
@@ -24,7 +23,6 @@ internal class DefaultAuthRepository(
 
     override suspend fun login(login: String, password: String): Either<DomainError, Unit> = either {
         val response = authApi.login(login, password)
-            .mapLeft(NetworkError::toDomain)
             .bind()
 
         response.token?.let { tokenStorage.saveToken(it) }
@@ -32,7 +30,6 @@ internal class DefaultAuthRepository(
 
     override suspend fun logout(): Either<DomainError, Unit> = either {
         val result = authApi.logout()
-            .mapLeft(NetworkError::toDomain)
         
         tokenStorage.clearToken()
         
@@ -41,11 +38,9 @@ internal class DefaultAuthRepository(
 
     override suspend fun socialLogin(provider: SocialType): Either<DomainError, Unit> = either {
         val state = authApi.socialLogin(provider.toDto())
-            .mapLeft(NetworkError::toDomain)
             .bind().state
 
         val response = authApi.socialAuthenticate(state)
-            .mapLeft(NetworkError::toDomain)
             .bind()
 
         response.token?.let { tokenStorage.saveToken(it) }
@@ -53,7 +48,6 @@ internal class DefaultAuthRepository(
 
     override suspend fun forgotPassword(email: String): Either<DomainError, Unit> = authApi
         .forgotPassword(email)
-        .mapLeft(NetworkError::toDomain)
 
     override suspend fun resetPassword(
         token: String,
@@ -61,5 +55,4 @@ internal class DefaultAuthRepository(
         passwordConfirmation: String
     ): Either<DomainError, Unit> = authApi
         .resetPassword(token, password, passwordConfirmation)
-        .mapLeft(NetworkError::toDomain)
 }

--- a/shared/core/data/impl/src/commonMain/kotlin/com/xbot/data/repository/DefaultCatalogRepository.kt
+++ b/shared/core/data/impl/src/commonMain/kotlin/com/xbot/data/repository/DefaultCatalogRepository.kt
@@ -2,7 +2,6 @@ package com.xbot.data.repository
 
 import androidx.paging.PagingSource
 import arrow.core.Either
-import arrow.core.getOrElse
 import com.xbot.data.datasource.CommonPagingSource
 import com.xbot.data.mapper.toDomain
 import com.xbot.data.mapper.toDto
@@ -17,7 +16,6 @@ import com.xbot.domain.models.enums.Season
 import com.xbot.domain.models.enums.SortingType
 import com.xbot.domain.models.filters.CatalogQuery
 import com.xbot.network.api.CatalogApi
-import com.xbot.network.client.NetworkError
 import com.xbot.network.models.dto.GenreDto
 import com.xbot.network.models.dto.ReleaseDto
 import com.xbot.network.models.enums.AgeRatingDto
@@ -35,7 +33,7 @@ internal class DefaultCatalogRepository(
     override fun getCatalogReleases(search: String?, filters: CatalogQuery?): PagingSource<Int, Release> {
         return CommonPagingSource(
             loadPage = { page, limit ->
-                val result = catalogApi.getCatalogReleases(
+                catalogApi.getCatalogReleases(
                     page = page,
                     limit = limit,
                     search = search,
@@ -48,13 +46,12 @@ internal class DefaultCatalogRepository(
                     ageRatings = filters?.ageRatings?.map(AgeRating::toDto),
                     publishStatuses = filters?.publishStatuses?.map(PublishStatus::toDto),
                     productionStatuses = filters?.productionStatuses?.map(ProductionStatus::toDto),
-                ).getOrElse { error ->
-                    throw error.toDomain()
+                ).map { result ->
+                    CommonPagingSource.PaginatedResponse(
+                        items = result.data.map(ReleaseDto::toDomain),
+                        total = result.meta.pagination.total,
+                    )
                 }
-                CommonPagingSource.PaginatedResponse(
-                    items = result.data.map(ReleaseDto::toDomain),
-                    total = result.meta.pagination.total
-                )
             }
         )
     }
@@ -78,48 +75,39 @@ internal class DefaultCatalogRepository(
             publishStatuses = filters?.publishStatuses?.map(PublishStatus::toDto),
             productionStatuses = filters?.productionStatuses?.map(ProductionStatus::toDto),
         )
-        .mapLeft(NetworkError::toDomain)
         .map { it.data.map(ReleaseDto::toDomain) }
 
     override suspend fun getCatalogAgeRatings(): Either<DomainError, List<AgeRating>> = catalogApi
         .getCatalogAgeRatings()
-        .mapLeft(NetworkError::toDomain)
         .map { it.map(AgeRatingDto::toDomain) }
 
     override suspend fun getCatalogGenres(): Either<DomainError, List<Genre>> = catalogApi
         .getCatalogGenres()
-        .mapLeft(NetworkError::toDomain)
         .map { it.map(GenreDto::toDomain) }
 
     override suspend fun getCatalogProductionStatuses(): Either<DomainError, List<ProductionStatus>> =
         catalogApi
             .getCatalogProductionStatuses()
-            .mapLeft(NetworkError::toDomain)
             .map { it.map(ProductionStatusDto::toDomain) }
 
     override suspend fun getCatalogPublishStatuses(): Either<DomainError, List<PublishStatus>> =
         catalogApi
             .getCatalogPublishStatuses()
-            .mapLeft(NetworkError::toDomain)
             .map { it.map(PublishStatusDto::toDomain) }
 
     override suspend fun getCatalogSeasons(): Either<DomainError, List<Season>> = catalogApi
         .getCatalogSeasons()
-        .mapLeft(NetworkError::toDomain)
         .map { it.map(SeasonDto::toDomain) }
 
     override suspend fun getCatalogSortingTypes(): Either<DomainError, List<SortingType>> = catalogApi
         .getCatalogSortingTypes()
-        .mapLeft(NetworkError::toDomain)
         .map { it.map(SortingTypeDto::toDomain) }
 
     override suspend fun getCatalogReleaseTypes(): Either<DomainError, List<ReleaseType>> = catalogApi
         .getCatalogReleaseTypes()
-        .mapLeft(NetworkError::toDomain)
         .map { it.map(ReleaseTypeDto::toDomain) }
 
     override suspend fun getCatalogYears(): Either<DomainError, IntRange> = catalogApi
         .getCatalogYears()
-        .mapLeft(NetworkError::toDomain)
         .map { years -> years.first()..years.last() }
 }

--- a/shared/core/data/impl/src/commonMain/kotlin/com/xbot/data/repository/DefaultFranchisesRepository.kt
+++ b/shared/core/data/impl/src/commonMain/kotlin/com/xbot/data/repository/DefaultFranchisesRepository.kt
@@ -8,7 +8,6 @@ import com.xbot.domain.models.Franchise
 import com.xbot.domain.models.Release
 import com.xbot.network.api.FranchisesApi
 import com.xbot.network.api.ReleasesApi
-import com.xbot.network.client.NetworkError
 import com.xbot.network.models.dto.FranchiseDto
 import org.koin.core.annotation.Singleton
 
@@ -19,32 +18,26 @@ internal class DefaultFranchisesRepository(
 ) : FranchisesRepository {
     override suspend fun getFranchises(): Either<DomainError, List<Franchise>> = franchisesApi
         .getFranchises()
-        .mapLeft(NetworkError::toDomain)
         .map { it.map(FranchiseDto::toDomain) }
 
     override suspend fun getFranchise(franchiseId: String): Either<DomainError, Franchise> = franchisesApi
         .getFranchise(franchiseId)
-        .mapLeft(NetworkError::toDomain)
         .map(FranchiseDto::toDomain)
 
     override suspend fun getRandomFranchises(limit: Int): Either<DomainError, List<Franchise>> = franchisesApi
         .getFranchisesRandom(limit)
-        .mapLeft(NetworkError::toDomain)
         .map { it.map(FranchiseDto::toDomain) }
 
     override suspend fun getReleaseFranchises(releaseId: Int): Either<DomainError, List<Franchise>> = franchisesApi
         .getFranchisesByRelease(releaseId)
-        .mapLeft(NetworkError::toDomain)
         .map { it.map(FranchiseDto::toDomain) }
 
     override suspend fun getFranchiseReleases(aliasOrId: String): Either<DomainError, List<Release>> = either {
         val releaseId = aliasOrId.toIntOrNull() ?: releasesApi.getRelease(aliasOrId)
-            .mapLeft(NetworkError::toDomain)
             .bind()
             .id
 
         val franchises = franchisesApi.getFranchisesByRelease(releaseId)
-            .mapLeft(NetworkError::toDomain)
             .bind()
 
         franchises

--- a/shared/core/data/impl/src/commonMain/kotlin/com/xbot/data/repository/DefaultGenresRepository.kt
+++ b/shared/core/data/impl/src/commonMain/kotlin/com/xbot/data/repository/DefaultGenresRepository.kt
@@ -2,14 +2,12 @@ package com.xbot.data.repository
 
 import androidx.paging.PagingSource
 import arrow.core.Either
-import arrow.core.getOrElse
 import com.xbot.data.datasource.CommonPagingSource
 import com.xbot.data.mapper.toDomain
 import com.xbot.domain.models.DomainError
 import com.xbot.domain.models.Genre
 import com.xbot.domain.models.Release
 import com.xbot.network.api.GenresApi
-import com.xbot.network.client.NetworkError
 import com.xbot.network.models.dto.GenreDto
 import com.xbot.network.models.dto.ReleaseDto
 import org.koin.core.annotation.Singleton
@@ -20,33 +18,29 @@ internal class DefaultGenresRepository(
 ) : GenresRepository {
     override suspend fun getGenres(): Either<DomainError, List<Genre>> = genresApi
         .getGenres()
-        .mapLeft(NetworkError::toDomain)
         .map { it.map(GenreDto::toDomain) }
 
     override suspend fun getGenre(genreId: Int): Either<DomainError, Genre> = genresApi
         .getGenre(genreId)
-        .mapLeft(NetworkError::toDomain)
         .map(GenreDto::toDomain)
 
     override suspend fun getRandomGenres(limit: Int): Either<DomainError, List<Genre>> = genresApi
         .getRandomGenres(limit)
-        .mapLeft(NetworkError::toDomain)
         .map { it.map(GenreDto::toDomain) }
 
     override fun getGenreReleases(genreId: Int): PagingSource<Int, Release> {
         return CommonPagingSource(
             loadPage = { page, limit ->
-                val result = genresApi.getGenreReleases(
+                genresApi.getGenreReleases(
                     genreId = genreId,
                     page = page,
                     limit = limit,
-                ).getOrElse { error ->
-                    throw error.toDomain()
+                ).map { result ->
+                    CommonPagingSource.PaginatedResponse(
+                        items = result.data.map(ReleaseDto::toDomain),
+                        total = result.meta.pagination.total,
+                    )
                 }
-                CommonPagingSource.PaginatedResponse(
-                    items = result.data.map(ReleaseDto::toDomain),
-                    total = result.meta.pagination.total
-                )
             }
         )
     }

--- a/shared/core/data/impl/src/commonMain/kotlin/com/xbot/data/repository/DefaultProfileRepository.kt
+++ b/shared/core/data/impl/src/commonMain/kotlin/com/xbot/data/repository/DefaultProfileRepository.kt
@@ -1,6 +1,7 @@
 package com.xbot.data.repository
 
 import arrow.core.Either
+import arrow.core.left
 import com.xbot.data.mapper.toDomain
 import com.xbot.domain.models.DomainError
 import com.xbot.domain.models.User
@@ -15,7 +16,15 @@ internal class DefaultProfileRepository(
         .getProfile()
         .map(com.xbot.network.models.dto.ProfileDto::toDomain)
 
-    override suspend fun updateProfile(user: User): Either<DomainError, User> = profileApi
-        .getProfile()
-        .map(com.xbot.network.models.dto.ProfileDto::toDomain)
+    /**
+     * Not yet wired to a backend endpoint — [ProfileApi] exposes no update route.
+     * Returning a typed [DomainError.UnknownError] surfaces "unimplemented" instead of
+     * silently returning the unmodified profile (the previous behaviour was a
+     * copy-paste of [getProfile] that ignored [user]). Replace with a real API call
+     * once the backend contract is defined.
+     */
+    override suspend fun updateProfile(user: User): Either<DomainError, User> =
+        DomainError.UnknownError(
+            NotImplementedError("ProfileApi.updateProfile is not yet supported by the backend"),
+        ).left()
 }

--- a/shared/core/data/impl/src/commonMain/kotlin/com/xbot/data/repository/DefaultProfileRepository.kt
+++ b/shared/core/data/impl/src/commonMain/kotlin/com/xbot/data/repository/DefaultProfileRepository.kt
@@ -5,7 +5,6 @@ import com.xbot.data.mapper.toDomain
 import com.xbot.domain.models.DomainError
 import com.xbot.domain.models.User
 import com.xbot.network.api.ProfileApi
-import com.xbot.network.client.NetworkError
 import org.koin.core.annotation.Singleton
 
 @Singleton
@@ -14,11 +13,9 @@ internal class DefaultProfileRepository(
 ) : ProfileRepository {
     override suspend fun getProfile(): Either<DomainError, User> = profileApi
         .getProfile()
-        .mapLeft(NetworkError::toDomain)
         .map(com.xbot.network.models.dto.ProfileDto::toDomain)
 
     override suspend fun updateProfile(user: User): Either<DomainError, User> = profileApi
         .getProfile()
-        .mapLeft(NetworkError::toDomain)
         .map(com.xbot.network.models.dto.ProfileDto::toDomain)
 }

--- a/shared/core/data/impl/src/commonMain/kotlin/com/xbot/data/repository/DefaultReleasesRepository.kt
+++ b/shared/core/data/impl/src/commonMain/kotlin/com/xbot/data/repository/DefaultReleasesRepository.kt
@@ -2,7 +2,6 @@ package com.xbot.data.repository
 
 import androidx.paging.PagingSource
 import arrow.core.Either
-import arrow.core.getOrElse
 import com.xbot.data.datasource.CommonPagingSource
 import com.xbot.data.mapper.toDomain
 import com.xbot.data.mapper.toReleaseDetails
@@ -12,7 +11,6 @@ import com.xbot.domain.models.ReleaseDetails
 import com.xbot.domain.models.ReleaseMember
 import com.xbot.network.api.ReleasesApi
 import com.xbot.network.api.SearchApi
-import com.xbot.network.client.NetworkError
 import com.xbot.network.models.dto.ReleaseDto
 import com.xbot.network.models.dto.ReleaseMemberDto
 import org.koin.core.annotation.Singleton
@@ -24,12 +22,10 @@ internal class DefaultReleasesRepository(
 ) : ReleasesRepository {
     override suspend fun getLatestReleases(limit: Int): Either<DomainError, List<Release>> = releasesApi
         .getLatestReleases(limit)
-        .mapLeft(NetworkError::toDomain)
         .map { it.map(ReleaseDto::toDomain) }
 
     override suspend fun getRandomReleases(limit: Int): Either<DomainError, List<Release>> = releasesApi
         .getRandomReleases(limit)
-        .mapLeft(NetworkError::toDomain)
         .map { it.map(ReleaseDto::toDomain) }
 
     override fun getReleasesList(
@@ -38,34 +34,30 @@ internal class DefaultReleasesRepository(
     ): PagingSource<Int, Release> {
         return CommonPagingSource(
             loadPage = { page, limit ->
-                val result = releasesApi.getReleasesList(
+                releasesApi.getReleasesList(
                     ids = ids,
                     aliases = aliases,
                     page = page,
                     limit = limit,
-                ).getOrElse { error ->
-                    throw error.toDomain()
+                ).map { result ->
+                    CommonPagingSource.PaginatedResponse(
+                        items = result.data.map(ReleaseDto::toDomain),
+                        total = result.meta.pagination.total,
+                    )
                 }
-                CommonPagingSource.PaginatedResponse(
-                    items = result.data.map(ReleaseDto::toDomain),
-                    total = result.meta.pagination.total
-                )
             }
         )
     }
 
     override suspend fun getRelease(aliasOrId: String): Either<DomainError, ReleaseDetails> = releasesApi
         .getRelease(aliasOrId)
-        .mapLeft(NetworkError::toDomain)
         .map(ReleaseDto::toReleaseDetails)
 
     override suspend fun getReleaseMembers(aliasOrId: String): Either<DomainError, List<ReleaseMember>> = releasesApi
         .getReleaseMembers(aliasOrId)
-        .mapLeft(NetworkError::toDomain)
         .map { it.map(ReleaseMemberDto::toDomain) }
 
     override suspend fun searchReleases(query: String): Either<DomainError, List<Release>> = searchApi
         .searchReleases(query)
-        .mapLeft(NetworkError::toDomain)
         .map { it.map(ReleaseDto::toDomain) }
 }

--- a/shared/core/data/impl/src/commonMain/kotlin/com/xbot/data/repository/DefaultScheduleRepository.kt
+++ b/shared/core/data/impl/src/commonMain/kotlin/com/xbot/data/repository/DefaultScheduleRepository.kt
@@ -9,7 +9,6 @@ import com.xbot.domain.models.Schedule
 import com.xbot.domain.models.enums.Season
 import com.xbot.network.api.ReleasesApi
 import com.xbot.network.api.ScheduleApi
-import com.xbot.network.client.NetworkError
 import com.xbot.network.models.dto.ScheduleDto
 import kotlinx.datetime.DayOfWeek
 import kotlinx.datetime.LocalDate
@@ -25,12 +24,10 @@ internal class DefaultScheduleRepository(
 ) : ScheduleRepository {
     override suspend fun getScheduleNow(): Either<DomainError, List<Schedule>> = scheduleApi
         .getScheduleNow()
-        .mapLeft(NetworkError::toDomain)
         .map { schedule -> schedule["today"]?.mapNotNull(ScheduleDto::toDomain) ?: emptyList() }
 
     override suspend fun getScheduleWeek(): Either<DomainError, Map<DayOfWeek, List<Schedule>>> = scheduleApi
         .getScheduleWeek()
-        .mapLeft(NetworkError::toDomain)
         .map { schedule ->
             schedule
                 .groupBy(
@@ -53,7 +50,6 @@ internal class DefaultScheduleRepository(
 
     override suspend fun getCurrentSeason(): Either<DomainError, Season> = releasesApi
         .getLatestReleases(10)
-        .mapLeft(NetworkError::toDomain)
         .map { releases ->
             releases
                 .map { it.season?.toDomain() }
@@ -65,7 +61,6 @@ internal class DefaultScheduleRepository(
 
     override suspend fun getCurrentYear(): Either<DomainError, Int> = releasesApi
         .getLatestReleases(10)
-        .mapLeft(NetworkError::toDomain)
         .map { releases ->
             releases
                 .map { it.year }

--- a/shared/core/domain/api/src/commonMain/kotlin/com/xbot/domain/models/DomainError.kt
+++ b/shared/core/domain/api/src/commonMain/kotlin/com/xbot/domain/models/DomainError.kt
@@ -1,8 +1,26 @@
 package com.xbot.domain.models
 
-sealed class DomainError(override val message: String? = null, override val cause: Throwable? = null) : Exception(message, cause) {
+sealed class DomainError(
+    override val message: String? = null,
+    override val cause: Throwable? = null,
+) : Exception(message, cause) {
     data class HttpError(val code: Int, override val message: String?) : DomainError(message)
     data class SerializationError(override val cause: Throwable) : DomainError(cause.message, cause)
     data class ConnectionError(override val cause: Throwable) : DomainError(cause.message, cause)
+    data class Timeout(override val cause: Throwable?) : DomainError("Request timed out", cause)
+    data object NoConnection : DomainError("No network available")
     data class UnknownError(override val cause: Throwable) : DomainError(cause.message, cause)
+
+    /**
+     * Retry predicate used by ResilientHttpRequester's Schedule.
+     * NoConnection is intentionally NOT retryable — it's gated *before* the request by
+     * the connectivity pre-check; waiting for reconnection is a different policy
+     * (observable via ConnectivityMonitor.observe()).
+     */
+    val isRetryable: Boolean
+        get() = when (this) {
+            is ConnectionError, is Timeout -> true
+            is HttpError -> code in 500..599 || code == 429 || code == 408
+            is SerializationError, is UnknownError, NoConnection -> false
+        }
 }

--- a/shared/core/network/api/build.gradle.kts
+++ b/shared/core/network/api/build.gradle.kts
@@ -20,6 +20,7 @@ kotlin {
 
     @OptIn(ExperimentalKotlinGradlePluginApi::class)
     dependencies {
+        api(projects.shared.core.domain.api)
         implementation(libs.kotlinx.serialization.json)
         implementation(libs.ktor.client.auth)
         implementation(libs.arrow.core)

--- a/shared/core/network/api/src/commonMain/kotlin/com/xbot/network/api/AdsApi.kt
+++ b/shared/core/network/api/src/commonMain/kotlin/com/xbot/network/api/AdsApi.kt
@@ -1,10 +1,10 @@
 package com.xbot.network.api
 
 import arrow.core.Either
-import com.xbot.network.client.NetworkError
+import com.xbot.domain.models.DomainError
 import com.xbot.network.models.dto.VastDto
 
 interface AdsApi {
-    suspend fun getVasts(): Either<NetworkError, List<VastDto>>
-    suspend fun getVastsChain(): Either<NetworkError, String>
+    suspend fun getVasts(): Either<DomainError, List<VastDto>>
+    suspend fun getVastsChain(): Either<DomainError, String>
 }

--- a/shared/core/network/api/src/commonMain/kotlin/com/xbot/network/api/AuthApi.kt
+++ b/shared/core/network/api/src/commonMain/kotlin/com/xbot/network/api/AuthApi.kt
@@ -1,7 +1,7 @@
 package com.xbot.network.api
 
 import arrow.core.Either
-import com.xbot.network.client.NetworkError
+import com.xbot.domain.models.DomainError
 import com.xbot.network.models.enums.SocialTypeDto
 import com.xbot.network.models.responses.AuthResponse
 import com.xbot.network.models.responses.LoginResponse
@@ -9,10 +9,10 @@ import com.xbot.network.models.responses.LogoutResponse
 import com.xbot.network.models.responses.SocialAuthResponse
 
 interface AuthApi {
-    suspend fun login(login: String, password: String): Either<NetworkError, LoginResponse>
-    suspend fun logout(): Either<NetworkError, LogoutResponse>
-    suspend fun socialLogin(provider: SocialTypeDto): Either<NetworkError, SocialAuthResponse>
-    suspend fun socialAuthenticate(state: String): Either<NetworkError, AuthResponse>
-    suspend fun forgotPassword(email: String): Either<NetworkError, Unit>
-    suspend fun resetPassword(token: String, password: String, passwordConfirmation: String): Either<NetworkError, Unit>
+    suspend fun login(login: String, password: String): Either<DomainError, LoginResponse>
+    suspend fun logout(): Either<DomainError, LogoutResponse>
+    suspend fun socialLogin(provider: SocialTypeDto): Either<DomainError, SocialAuthResponse>
+    suspend fun socialAuthenticate(state: String): Either<DomainError, AuthResponse>
+    suspend fun forgotPassword(email: String): Either<DomainError, Unit>
+    suspend fun resetPassword(token: String, password: String, passwordConfirmation: String): Either<DomainError, Unit>
 }

--- a/shared/core/network/api/src/commonMain/kotlin/com/xbot/network/api/CatalogApi.kt
+++ b/shared/core/network/api/src/commonMain/kotlin/com/xbot/network/api/CatalogApi.kt
@@ -1,7 +1,7 @@
 package com.xbot.network.api
 
 import arrow.core.Either
-import com.xbot.network.client.NetworkError
+import com.xbot.domain.models.DomainError
 import com.xbot.network.models.dto.GenreDto
 import com.xbot.network.models.dto.ReleaseDto
 import com.xbot.network.models.enums.AgeRatingDto
@@ -26,13 +26,13 @@ interface CatalogApi {
         ageRatings: List<AgeRatingDto>? = null,
         publishStatuses: List<PublishStatusDto>? = null,
         productionStatuses: List<ProductionStatusDto>? = null,
-    ): Either<NetworkError, PaginatedResponse<ReleaseDto>>
-    suspend fun getCatalogAgeRatings(): Either<NetworkError, List<AgeRatingDto>>
-    suspend fun getCatalogGenres(): Either<NetworkError, List<GenreDto>>
-    suspend fun getCatalogProductionStatuses(): Either<NetworkError, List<ProductionStatusDto>>
-    suspend fun getCatalogPublishStatuses(): Either<NetworkError, List<PublishStatusDto>>
-    suspend fun getCatalogSeasons(): Either<NetworkError, List<SeasonDto>>
-    suspend fun getCatalogSortingTypes(): Either<NetworkError, List<SortingTypeDto>>
-    suspend fun getCatalogReleaseTypes(): Either<NetworkError, List<ReleaseTypeDto>>
-    suspend fun getCatalogYears(): Either<NetworkError, List<Int>>
+    ): Either<DomainError, PaginatedResponse<ReleaseDto>>
+    suspend fun getCatalogAgeRatings(): Either<DomainError, List<AgeRatingDto>>
+    suspend fun getCatalogGenres(): Either<DomainError, List<GenreDto>>
+    suspend fun getCatalogProductionStatuses(): Either<DomainError, List<ProductionStatusDto>>
+    suspend fun getCatalogPublishStatuses(): Either<DomainError, List<PublishStatusDto>>
+    suspend fun getCatalogSeasons(): Either<DomainError, List<SeasonDto>>
+    suspend fun getCatalogSortingTypes(): Either<DomainError, List<SortingTypeDto>>
+    suspend fun getCatalogReleaseTypes(): Either<DomainError, List<ReleaseTypeDto>>
+    suspend fun getCatalogYears(): Either<DomainError, List<Int>>
 }

--- a/shared/core/network/api/src/commonMain/kotlin/com/xbot/network/api/CollectionApi.kt
+++ b/shared/core/network/api/src/commonMain/kotlin/com/xbot/network/api/CollectionApi.kt
@@ -1,7 +1,7 @@
 package com.xbot.network.api
 
 import arrow.core.Either
-import com.xbot.network.client.NetworkError
+import com.xbot.domain.models.DomainError
 import com.xbot.network.models.dto.GenreDto
 import com.xbot.network.models.dto.ReleaseDto
 import com.xbot.network.models.enums.AgeRatingDto
@@ -10,7 +10,7 @@ import com.xbot.network.models.enums.ReleaseTypeDto
 import com.xbot.network.models.responses.PaginatedResponse
 
 interface CollectionApi {
-    suspend fun getCollectionIds(): Either<NetworkError, Map<Int, CollectionTypeDto>>
+    suspend fun getCollectionIds(): Either<DomainError, Map<Int, CollectionTypeDto>>
     suspend fun getCollectionReleases(
         page: Int,
         limit: Int,
@@ -20,15 +20,15 @@ interface CollectionApi {
         years: List<Int>? = null,
         search: String? = null,
         ageRatings: List<AgeRatingDto>? = null
-    ): Either<NetworkError, PaginatedResponse<ReleaseDto>>
+    ): Either<DomainError, PaginatedResponse<ReleaseDto>>
     suspend fun addToCollections(
         collections: Map<Int, CollectionTypeDto> // releaseId to collectionType
-    ): Either<NetworkError, Map<Int, CollectionTypeDto>>
+    ): Either<DomainError, Map<Int, CollectionTypeDto>>
     suspend fun removeFromCollections(
         releaseIds: List<Int>
-    ): Either<NetworkError, Map<Int, CollectionTypeDto>>
-    suspend fun getCollectionAgeRatings(): Either<NetworkError, List<AgeRatingDto>>
-    suspend fun getCollectionGenres(): Either<NetworkError, List<GenreDto>>
-    suspend fun getCollectionReleaseTypes(): Either<NetworkError, List<ReleaseTypeDto>>
-    suspend fun getCollectionYears(): Either<NetworkError, List<Int>>
+    ): Either<DomainError, Map<Int, CollectionTypeDto>>
+    suspend fun getCollectionAgeRatings(): Either<DomainError, List<AgeRatingDto>>
+    suspend fun getCollectionGenres(): Either<DomainError, List<GenreDto>>
+    suspend fun getCollectionReleaseTypes(): Either<DomainError, List<ReleaseTypeDto>>
+    suspend fun getCollectionYears(): Either<DomainError, List<Int>>
 }

--- a/shared/core/network/api/src/commonMain/kotlin/com/xbot/network/api/EpisodesApi.kt
+++ b/shared/core/network/api/src/commonMain/kotlin/com/xbot/network/api/EpisodesApi.kt
@@ -1,11 +1,11 @@
 package com.xbot.network.api
 
 import arrow.core.Either
-import com.xbot.network.client.NetworkError
+import com.xbot.domain.models.DomainError
 import com.xbot.network.models.dto.EpisodeTimecodeDto
 import com.xbot.network.models.dto.EpisodeWithReleaseDto
 
 interface EpisodesApi {
-    suspend fun getEpisode(episodeId: Int): Either<NetworkError, EpisodeWithReleaseDto>
-    suspend fun getEpisodeTimecode(releaseEpisodeId: String): Either<NetworkError, EpisodeTimecodeDto>
+    suspend fun getEpisode(episodeId: Int): Either<DomainError, EpisodeWithReleaseDto>
+    suspend fun getEpisodeTimecode(releaseEpisodeId: String): Either<DomainError, EpisodeTimecodeDto>
 }

--- a/shared/core/network/api/src/commonMain/kotlin/com/xbot/network/api/FavoritesApi.kt
+++ b/shared/core/network/api/src/commonMain/kotlin/com/xbot/network/api/FavoritesApi.kt
@@ -1,7 +1,7 @@
 package com.xbot.network.api
 
 import arrow.core.Either
-import com.xbot.network.client.NetworkError
+import com.xbot.domain.models.DomainError
 import com.xbot.network.models.dto.GenreDto
 import com.xbot.network.models.dto.ReleaseDto
 import com.xbot.network.models.enums.AgeRatingDto
@@ -11,7 +11,7 @@ import com.xbot.network.models.enums.SortingTypeDto
 import com.xbot.network.models.responses.PaginatedResponse
 
 interface FavoritesApi {
-    suspend fun getFavoriteIds(): Either<NetworkError, List<Int>>
+    suspend fun getFavoriteIds(): Either<DomainError, List<Int>>
     suspend fun getFavoriteReleases(
         page: Int,
         limit: Int,
@@ -21,12 +21,12 @@ interface FavoritesApi {
         search: String? = null,
         sorting: SortingTypeDto? = null,
         ageRatings: List<AgeRatingDto>? = null
-    ): Either<NetworkError, PaginatedResponse<ReleaseDto>>
-    suspend fun addToFavorites(releaseIds: List<Int>): Either<NetworkError, List<Int>>
-    suspend fun removeFromFavorites(releaseIds: List<Int>): Either<NetworkError, List<Int>>
-    suspend fun getFavoriteAgeRatings(): Either<NetworkError, List<AgeRatingDto>>
-    suspend fun getFavoriteGenres(): Either<NetworkError, List<GenreDto>>
-    suspend fun getFavoriteSortingTypes(): Either<NetworkError, List<FavoriteSortingTypeDto>>
-    suspend fun getFavoriteReleaseTypes(): Either<NetworkError, List<ReleaseTypeDto>>
-    suspend fun getFavoriteYears(): Either<NetworkError, List<Int>>
+    ): Either<DomainError, PaginatedResponse<ReleaseDto>>
+    suspend fun addToFavorites(releaseIds: List<Int>): Either<DomainError, List<Int>>
+    suspend fun removeFromFavorites(releaseIds: List<Int>): Either<DomainError, List<Int>>
+    suspend fun getFavoriteAgeRatings(): Either<DomainError, List<AgeRatingDto>>
+    suspend fun getFavoriteGenres(): Either<DomainError, List<GenreDto>>
+    suspend fun getFavoriteSortingTypes(): Either<DomainError, List<FavoriteSortingTypeDto>>
+    suspend fun getFavoriteReleaseTypes(): Either<DomainError, List<ReleaseTypeDto>>
+    suspend fun getFavoriteYears(): Either<DomainError, List<Int>>
 }

--- a/shared/core/network/api/src/commonMain/kotlin/com/xbot/network/api/FranchisesApi.kt
+++ b/shared/core/network/api/src/commonMain/kotlin/com/xbot/network/api/FranchisesApi.kt
@@ -1,12 +1,12 @@
 package com.xbot.network.api
 
 import arrow.core.Either
-import com.xbot.network.client.NetworkError
+import com.xbot.domain.models.DomainError
 import com.xbot.network.models.dto.FranchiseDto
 
 interface FranchisesApi {
-    suspend fun getFranchises(): Either<NetworkError, List<FranchiseDto>>
-    suspend fun getFranchise(franchiseId: String): Either<NetworkError, FranchiseDto>
-    suspend fun getFranchisesRandom(limit: Int): Either<NetworkError, List<FranchiseDto>>
-    suspend fun getFranchisesByRelease(releaseId: Int): Either<NetworkError, List<FranchiseDto>>
+    suspend fun getFranchises(): Either<DomainError, List<FranchiseDto>>
+    suspend fun getFranchise(franchiseId: String): Either<DomainError, FranchiseDto>
+    suspend fun getFranchisesRandom(limit: Int): Either<DomainError, List<FranchiseDto>>
+    suspend fun getFranchisesByRelease(releaseId: Int): Either<DomainError, List<FranchiseDto>>
 }

--- a/shared/core/network/api/src/commonMain/kotlin/com/xbot/network/api/GenresApi.kt
+++ b/shared/core/network/api/src/commonMain/kotlin/com/xbot/network/api/GenresApi.kt
@@ -1,18 +1,18 @@
 package com.xbot.network.api
 
 import arrow.core.Either
-import com.xbot.network.client.NetworkError
+import com.xbot.domain.models.DomainError
 import com.xbot.network.models.dto.GenreDto
 import com.xbot.network.models.dto.ReleaseDto
 import com.xbot.network.models.responses.PaginatedResponse
 
 interface GenresApi {
-    suspend fun getGenres(): Either<NetworkError, List<GenreDto>>
-    suspend fun getGenre(genreId: Int): Either<NetworkError, GenreDto>
-    suspend fun getRandomGenres(limit: Int): Either<NetworkError, List<GenreDto>>
+    suspend fun getGenres(): Either<DomainError, List<GenreDto>>
+    suspend fun getGenre(genreId: Int): Either<DomainError, GenreDto>
+    suspend fun getRandomGenres(limit: Int): Either<DomainError, List<GenreDto>>
     suspend fun getGenreReleases(
         genreId: Int,
         page: Int,
         limit: Int
-    ): Either<NetworkError, PaginatedResponse<ReleaseDto>>
+    ): Either<DomainError, PaginatedResponse<ReleaseDto>>
 }

--- a/shared/core/network/api/src/commonMain/kotlin/com/xbot/network/api/OtpApi.kt
+++ b/shared/core/network/api/src/commonMain/kotlin/com/xbot/network/api/OtpApi.kt
@@ -1,12 +1,12 @@
 package com.xbot.network.api
 
 import arrow.core.Either
-import com.xbot.network.client.NetworkError
+import com.xbot.domain.models.DomainError
 import com.xbot.network.models.responses.LoginResponse
 import com.xbot.network.models.responses.OtpResponse
 
 interface OtpApi {
-    suspend fun getOtp(deviceId: String): Either<NetworkError, OtpResponse>
-    suspend fun acceptOtp(code: Int): Either<NetworkError, Unit>
-    suspend fun loginWithOtp(code: Int, deviceId: String): Either<NetworkError, LoginResponse>
+    suspend fun getOtp(deviceId: String): Either<DomainError, OtpResponse>
+    suspend fun acceptOtp(code: Int): Either<DomainError, Unit>
+    suspend fun loginWithOtp(code: Int, deviceId: String): Either<DomainError, LoginResponse>
 }

--- a/shared/core/network/api/src/commonMain/kotlin/com/xbot/network/api/ProfileApi.kt
+++ b/shared/core/network/api/src/commonMain/kotlin/com/xbot/network/api/ProfileApi.kt
@@ -1,9 +1,9 @@
 package com.xbot.network.api
 
 import arrow.core.Either
-import com.xbot.network.client.NetworkError
+import com.xbot.domain.models.DomainError
 import com.xbot.network.models.dto.ProfileDto
 
 interface ProfileApi {
-    suspend fun getProfile(): Either<NetworkError, ProfileDto>
+    suspend fun getProfile(): Either<DomainError, ProfileDto>
 }

--- a/shared/core/network/api/src/commonMain/kotlin/com/xbot/network/api/PromotionsApi.kt
+++ b/shared/core/network/api/src/commonMain/kotlin/com/xbot/network/api/PromotionsApi.kt
@@ -1,9 +1,9 @@
 package com.xbot.network.api
 
 import arrow.core.Either
-import com.xbot.network.client.NetworkError
+import com.xbot.domain.models.DomainError
 import com.xbot.network.models.dto.PromotionDto
 
 interface PromotionsApi {
-    suspend fun getPromotions(): Either<NetworkError, List<PromotionDto>>
+    suspend fun getPromotions(): Either<DomainError, List<PromotionDto>>
 }

--- a/shared/core/network/api/src/commonMain/kotlin/com/xbot/network/api/ReleasesApi.kt
+++ b/shared/core/network/api/src/commonMain/kotlin/com/xbot/network/api/ReleasesApi.kt
@@ -1,28 +1,28 @@
 package com.xbot.network.api
 
 import arrow.core.Either
-import com.xbot.network.client.NetworkError
+import com.xbot.domain.models.DomainError
 import com.xbot.network.models.dto.EpisodeTimecodeDto
 import com.xbot.network.models.dto.ReleaseDto
 import com.xbot.network.models.dto.ReleaseMemberDto
 import com.xbot.network.models.responses.PaginatedResponse
 
 interface ReleasesApi {
-    suspend fun getLatestReleases(limit: Int): Either<NetworkError, List<ReleaseDto>>
-    suspend fun getRandomReleases(limit: Int): Either<NetworkError, List<ReleaseDto>>
+    suspend fun getLatestReleases(limit: Int): Either<DomainError, List<ReleaseDto>>
+    suspend fun getRandomReleases(limit: Int): Either<DomainError, List<ReleaseDto>>
     suspend fun getReleasesList(
         ids: List<Int>? = null,
         aliases: List<String>? = null,
         page: Int = 1,
         limit: Int = 15
-    ): Either<NetworkError, PaginatedResponse<ReleaseDto>>
+    ): Either<DomainError, PaginatedResponse<ReleaseDto>>
     suspend fun getRelease(
         aliasOrId: String
-    ): Either<NetworkError, ReleaseDto>
+    ): Either<DomainError, ReleaseDto>
     suspend fun getReleaseMembers(
         aliasOrId: String
-    ): Either<NetworkError, List<ReleaseMemberDto>>
+    ): Either<DomainError, List<ReleaseMemberDto>>
     suspend fun getReleaseEpisodesTimecodes(
         aliasOrId: String
-    ): Either<NetworkError, List<EpisodeTimecodeDto>>
+    ): Either<DomainError, List<EpisodeTimecodeDto>>
 }

--- a/shared/core/network/api/src/commonMain/kotlin/com/xbot/network/api/ScheduleApi.kt
+++ b/shared/core/network/api/src/commonMain/kotlin/com/xbot/network/api/ScheduleApi.kt
@@ -1,10 +1,10 @@
 package com.xbot.network.api
 
 import arrow.core.Either
-import com.xbot.network.client.NetworkError
+import com.xbot.domain.models.DomainError
 import com.xbot.network.models.dto.ScheduleDto
 
 interface ScheduleApi {
-    suspend fun getScheduleNow(): Either<NetworkError, Map<String, List<ScheduleDto>>>
-    suspend fun getScheduleWeek(): Either<NetworkError, List<ScheduleDto>>
+    suspend fun getScheduleNow(): Either<DomainError, Map<String, List<ScheduleDto>>>
+    suspend fun getScheduleWeek(): Either<DomainError, List<ScheduleDto>>
 }

--- a/shared/core/network/api/src/commonMain/kotlin/com/xbot/network/api/SearchApi.kt
+++ b/shared/core/network/api/src/commonMain/kotlin/com/xbot/network/api/SearchApi.kt
@@ -1,9 +1,9 @@
 package com.xbot.network.api
 
 import arrow.core.Either
-import com.xbot.network.client.NetworkError
+import com.xbot.domain.models.DomainError
 import com.xbot.network.models.dto.ReleaseDto
 
 interface SearchApi {
-    suspend fun searchReleases(query: String): Either<NetworkError, List<ReleaseDto>>
+    suspend fun searchReleases(query: String): Either<DomainError, List<ReleaseDto>>
 }

--- a/shared/core/network/api/src/commonMain/kotlin/com/xbot/network/api/TeamsApi.kt
+++ b/shared/core/network/api/src/commonMain/kotlin/com/xbot/network/api/TeamsApi.kt
@@ -1,13 +1,13 @@
 package com.xbot.network.api
 
 import arrow.core.Either
-import com.xbot.network.client.NetworkError
+import com.xbot.domain.models.DomainError
 import com.xbot.network.models.dto.TeamDto
 import com.xbot.network.models.dto.TeamRoleDto
 import com.xbot.network.models.dto.TeamUserApi
 
 interface TeamsApi {
-    suspend fun getTeams(): Either<NetworkError, List<TeamDto>>
-    suspend fun getTeamRoles(): Either<NetworkError, List<TeamRoleDto>>
-    suspend fun getTeamUsers(): Either<NetworkError, List<TeamUserApi>>
+    suspend fun getTeams(): Either<DomainError, List<TeamDto>>
+    suspend fun getTeamRoles(): Either<DomainError, List<TeamRoleDto>>
+    suspend fun getTeamUsers(): Either<DomainError, List<TeamUserApi>>
 }

--- a/shared/core/network/api/src/commonMain/kotlin/com/xbot/network/api/TorrentsApi.kt
+++ b/shared/core/network/api/src/commonMain/kotlin/com/xbot/network/api/TorrentsApi.kt
@@ -1,15 +1,15 @@
 package com.xbot.network.api
 
 import arrow.core.Either
-import com.xbot.network.client.NetworkError
+import com.xbot.domain.models.DomainError
 import com.xbot.network.models.dto.TorrentDto
 import com.xbot.network.models.responses.PaginatedResponse
 
 interface TorrentsApi {
-    suspend fun getTorrents(page: Int, limit: Int): Either<NetworkError, PaginatedResponse<TorrentDto>>
-    suspend fun getTorrent(hashOrId: String): Either<NetworkError, TorrentDto>
-    suspend fun getTorrentFile(hashOrId: String, pk: String? = null): Either<NetworkError, ByteArray>
-    suspend fun getReleaseTorrents(releaseId: Int): Either<NetworkError, List<TorrentDto>>
-    suspend fun getTorrentsRss(limit: Int? = null, pk: String? = null): Either<NetworkError, String>
-    suspend fun getReleaseTorrentsRss(releaseId: Int, pk: String? = null): Either<NetworkError, String>
+    suspend fun getTorrents(page: Int, limit: Int): Either<DomainError, PaginatedResponse<TorrentDto>>
+    suspend fun getTorrent(hashOrId: String): Either<DomainError, TorrentDto>
+    suspend fun getTorrentFile(hashOrId: String, pk: String? = null): Either<DomainError, ByteArray>
+    suspend fun getReleaseTorrents(releaseId: Int): Either<DomainError, List<TorrentDto>>
+    suspend fun getTorrentsRss(limit: Int? = null, pk: String? = null): Either<DomainError, String>
+    suspend fun getReleaseTorrentsRss(releaseId: Int, pk: String? = null): Either<DomainError, String>
 }

--- a/shared/core/network/api/src/commonMain/kotlin/com/xbot/network/api/VideosApi.kt
+++ b/shared/core/network/api/src/commonMain/kotlin/com/xbot/network/api/VideosApi.kt
@@ -1,9 +1,9 @@
 package com.xbot.network.api
 
 import arrow.core.Either
-import com.xbot.network.client.NetworkError
+import com.xbot.domain.models.DomainError
 import com.xbot.network.models.dto.VideoDto
 
 interface VideosApi {
-    suspend fun getVideos(limit: Int): Either<NetworkError, List<VideoDto>>
+    suspend fun getVideos(limit: Int): Either<DomainError, List<VideoDto>>
 }

--- a/shared/core/network/api/src/commonMain/kotlin/com/xbot/network/api/ViewsApi.kt
+++ b/shared/core/network/api/src/commonMain/kotlin/com/xbot/network/api/ViewsApi.kt
@@ -1,13 +1,13 @@
 package com.xbot.network.api
 
 import arrow.core.Either
-import com.xbot.network.client.NetworkError
+import com.xbot.domain.models.DomainError
 import com.xbot.network.models.dto.TimecodeApi
 
 interface ViewsApi {
-    suspend fun getTimecodes(): Either<NetworkError, List<TimecodeApi>>
-    suspend fun updateTimecodes(timecodes: List<UpdateTimecodesRequest>): Either<NetworkError, List<TimecodeApi>>
-    suspend fun deleteTimecodes(episodeIds: List<String>): Either<NetworkError, List<TimecodeApi>>
+    suspend fun getTimecodes(): Either<DomainError, List<TimecodeApi>>
+    suspend fun updateTimecodes(timecodes: List<UpdateTimecodesRequest>): Either<DomainError, List<TimecodeApi>>
+    suspend fun deleteTimecodes(episodeIds: List<String>): Either<DomainError, List<TimecodeApi>>
 
     data class UpdateTimecodesRequest(
         val episodeId: String,

--- a/shared/core/network/api/src/commonMain/kotlin/com/xbot/network/client/NetworkError.kt
+++ b/shared/core/network/api/src/commonMain/kotlin/com/xbot/network/client/NetworkError.kt
@@ -1,8 +1,0 @@
-package com.xbot.network.client
-
-sealed class NetworkError(override val message: String? = null, override val cause: Throwable? = null) : Exception(message, cause) {
-    data class HttpError(val code: Int, override val message: String?) : NetworkError(message)
-    data class SerializationError(override val cause: Throwable) : NetworkError(cause.message, cause)
-    data class ConnectionError(override val cause: Throwable) : NetworkError(cause.message, cause)
-    data class UnknownError(override val cause: Throwable) : NetworkError(cause.message, cause)
-}

--- a/shared/core/network/api/src/commonMain/kotlin/com/xbot/network/connectivity/ConnectivityMonitor.kt
+++ b/shared/core/network/api/src/commonMain/kotlin/com/xbot/network/connectivity/ConnectivityMonitor.kt
@@ -1,0 +1,32 @@
+package com.xbot.network.connectivity
+
+import kotlinx.coroutines.flow.Flow
+
+/**
+ * Discrete connectivity state the app can observe or poll for pre-flight checks.
+ */
+enum class ConnectivityState { Available, Unavailable }
+
+/**
+ * Observes whether the device has a usable network route.
+ *
+ * Platform-specific implementations live in `:network:impl` and are registered as Koin
+ * singletons through `@ComponentScan("com.xbot.network")`.
+ *
+ * **Contract:**
+ * - [currentState] is a cheap synchronous snapshot used as a pre-flight gate in the
+ *   HTTP layer. It must never block on I/O.
+ * - [observe] emits the *current* state immediately on subscription and then every
+ *   transition. Suitable for driving UI banners.
+ * - On platforms where the underlying platform cannot reliably report reachability
+ *   (e.g., plain JVM/desktop), the implementation defaults to
+ *   [ConnectivityState.Available] — the resilience layer prefers attempting a request
+ *   to failing pessimistically.
+ */
+interface ConnectivityMonitor {
+    val currentState: ConnectivityState
+
+    fun isOnline(): Boolean = currentState == ConnectivityState.Available
+
+    fun observe(): Flow<ConnectivityState>
+}

--- a/shared/core/network/impl/build.gradle.kts
+++ b/shared/core/network/impl/build.gradle.kts
@@ -31,6 +31,7 @@ kotlin {
         implementation(libs.kotlinx.atomicfu)
         implementation(libs.kotlinx.serialization.json)
         implementation(libs.arrow.core)
+        implementation(libs.arrow.resilience)
         implementation(libs.koin.core)
         implementation(libs.koin.annotations)
         implementation(libs.kermit)

--- a/shared/core/network/impl/src/androidMain/kotlin/com/xbot/network/connectivity/AndroidConnectivityMonitor.kt
+++ b/shared/core/network/impl/src/androidMain/kotlin/com/xbot/network/connectivity/AndroidConnectivityMonitor.kt
@@ -1,0 +1,81 @@
+package com.xbot.network.connectivity
+
+import android.content.Context
+import android.net.ConnectivityManager
+import android.net.Network
+import android.net.NetworkCapabilities
+import android.net.NetworkRequest
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import org.koin.core.annotation.Singleton
+
+/**
+ * Android connectivity monitor backed by [ConnectivityManager.NetworkCallback].
+ *
+ * Registered once at app startup as a Koin singleton; the callback stays alive for the
+ * process lifetime. [currentState] is maintained as a `MutableStateFlow`, keeping the
+ * synchronous read (used by the HTTP pre-flight check) cheap and allocation-free.
+ *
+ * Requires `android.permission.ACCESS_NETWORK_STATE` in the manifest.
+ */
+@Singleton
+internal class AndroidConnectivityMonitor(
+    context: Context,
+) : ConnectivityMonitor {
+
+    private val connectivityManager: ConnectivityManager =
+        context.applicationContext.getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager
+
+    private val state = MutableStateFlow(readInitialState())
+
+    private val callback = object : ConnectivityManager.NetworkCallback() {
+        override fun onAvailable(network: Network) {
+            // Availability alone is not enough — wait for capability confirmation below.
+        }
+
+        override fun onCapabilitiesChanged(network: Network, capabilities: NetworkCapabilities) {
+            state.value = if (capabilities.isValidated()) {
+                ConnectivityState.Available
+            } else {
+                ConnectivityState.Unavailable
+            }
+        }
+
+        override fun onLost(network: Network) {
+            state.value = ConnectivityState.Unavailable
+        }
+
+        override fun onUnavailable() {
+            state.value = ConnectivityState.Unavailable
+        }
+    }
+
+    init {
+        val request = NetworkRequest.Builder()
+            .addCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET)
+            .addCapability(NetworkCapabilities.NET_CAPABILITY_VALIDATED)
+            .build()
+        runCatching { connectivityManager.registerNetworkCallback(request, callback) }
+    }
+
+    override val currentState: ConnectivityState
+        get() = state.value
+
+    override fun observe(): Flow<ConnectivityState> = state.asStateFlow()
+
+    private fun readInitialState(): ConnectivityState {
+        val active = connectivityManager.activeNetwork ?: return ConnectivityState.Unavailable
+        val capabilities = connectivityManager.getNetworkCapabilities(active)
+            ?: return ConnectivityState.Unavailable
+        return if (capabilities.isValidated()) {
+            ConnectivityState.Available
+        } else {
+            ConnectivityState.Unavailable
+        }
+    }
+
+    private fun NetworkCapabilities.isValidated(): Boolean =
+        hasCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET) &&
+            hasCapability(NetworkCapabilities.NET_CAPABILITY_VALIDATED)
+}

--- a/shared/core/network/impl/src/androidMain/kotlin/com/xbot/network/connectivity/AndroidConnectivityMonitor.kt
+++ b/shared/core/network/impl/src/androidMain/kotlin/com/xbot/network/connectivity/AndroidConnectivityMonitor.kt
@@ -5,6 +5,7 @@ import android.net.ConnectivityManager
 import android.net.Network
 import android.net.NetworkCapabilities
 import android.net.NetworkRequest
+import co.touchlab.kermit.Logger
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -43,9 +44,18 @@ internal class AndroidConnectivityMonitor(
     private val state = MutableStateFlow(readInitialState())
 
     private val callback = object : ConnectivityManager.NetworkCallback() {
+        // Primary signal: a network matching our NetworkRequest (which includes
+        // NET_CAPABILITY_VALIDATED) has come up. Add unconditionally — by the time
+        // onAvailable fires, the system has already validated the network against
+        // our request's capability filter.
+        override fun onAvailable(network: Network) {
+            validatedNetworks.add(network)
+            publish()
+        }
+
         override fun onCapabilitiesChanged(network: Network, capabilities: NetworkCapabilities) {
-            // The NetworkRequest filters by VALIDATED, but a network can lose that
-            // capability mid-flight (e.g., captive portal detected) — check defensively.
+            // Capabilities can flip post-availability (e.g., captive portal detected
+            // mid-session strips VALIDATED) — re-check and sync the set accordingly.
             if (capabilities.isValidated()) {
                 validatedNetworks.add(network)
             } else {
@@ -72,7 +82,26 @@ internal class AndroidConnectivityMonitor(
             .addCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET)
             .addCapability(NetworkCapabilities.NET_CAPABILITY_VALIDATED)
             .build()
-        runCatching { connectivityManager.registerNetworkCallback(request, callback) }
+        try {
+            connectivityManager.registerNetworkCallback(request, callback)
+        } catch (e: SecurityException) {
+            // Most likely cause: missing `android.permission.ACCESS_NETWORK_STATE`.
+            // Without the callback the monitor can only ever report the seeded
+            // initial state, so every `isOnline()` check risks a false negative
+            // (offline banner) or false positive (wasted HTTP attempts). Surface
+            // the cause loudly — swallowing it silently has burned us before.
+            Logger.e(e) {
+                "Failed to register ConnectivityManager.NetworkCallback — connectivity " +
+                    "state will be frozen at '${state.value}'. Verify ACCESS_NETWORK_STATE " +
+                    "permission is declared in the manifest."
+            }
+        } catch (e: RuntimeException) {
+            // TooManyRequestsException and similar unchecked throws at the system boundary.
+            Logger.e(e) {
+                "Unexpected failure registering ConnectivityManager.NetworkCallback — " +
+                    "connectivity state will be frozen at '${state.value}'."
+            }
+        }
     }
 
     override val currentState: ConnectivityState

--- a/shared/core/network/impl/src/androidMain/kotlin/com/xbot/network/connectivity/AndroidConnectivityMonitor.kt
+++ b/shared/core/network/impl/src/androidMain/kotlin/com/xbot/network/connectivity/AndroidConnectivityMonitor.kt
@@ -119,15 +119,37 @@ internal class AndroidConnectivityMonitor(
 
     // Seed the state before the callback fires at least once. The callback will then
     // take over and the set becomes the source of truth.
-    private fun readInitialState(): ConnectivityState {
+    //
+    // NOTE: this runs during property initialization — *before* the init block's
+    // try/catch. A thrown SecurityException (missing ACCESS_NETWORK_STATE) or a
+    // RuntimeException from the system service would therefore crash class
+    // construction, making the app unusable before our init block's logging can
+    // diagnose the cause. Catch both here and fall back to `Available` — treating
+    // "we can't tell" as "assume online" is the less-bad UX than freezing every
+    // `isOnline()` check to `false` (which would make the app appear permanently
+    // offline). The root cause is still surfaced via Kermit for troubleshooting.
+    private fun readInitialState(): ConnectivityState = try {
         val active = connectivityManager.activeNetwork ?: return ConnectivityState.Unavailable
         val capabilities = connectivityManager.getNetworkCapabilities(active)
             ?: return ConnectivityState.Unavailable
-        return if (capabilities.isValidated()) {
+        if (capabilities.isValidated()) {
             ConnectivityState.Available
         } else {
             ConnectivityState.Unavailable
         }
+    } catch (e: SecurityException) {
+        Logger.e(e) {
+            "Failed to read initial connectivity state — ACCESS_NETWORK_STATE permission " +
+                "likely missing from the manifest. Falling back to 'Available' so requests " +
+                "are not universally short-circuited as offline."
+        }
+        ConnectivityState.Available
+    } catch (e: RuntimeException) {
+        Logger.e(e) {
+            "Unexpected failure reading initial connectivity state — " +
+                "falling back to 'Available'."
+        }
+        ConnectivityState.Available
     }
 
     private fun NetworkCapabilities.isValidated(): Boolean =

--- a/shared/core/network/impl/src/androidMain/kotlin/com/xbot/network/connectivity/AndroidConnectivityMonitor.kt
+++ b/shared/core/network/impl/src/androidMain/kotlin/com/xbot/network/connectivity/AndroidConnectivityMonitor.kt
@@ -9,13 +9,21 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import org.koin.core.annotation.Singleton
+import java.util.concurrent.ConcurrentHashMap
 
 /**
  * Android connectivity monitor backed by [ConnectivityManager.NetworkCallback].
  *
+ * A phone typically holds more than one active network at once (Wi-Fi + cellular), and
+ * "online" means *at least one* is validated. We track the set of currently validated
+ * [Network] handles and derive state from `set.isNotEmpty()` — so losing Wi-Fi while
+ * LTE is still up does not flip the state to offline. The set is a
+ * [ConcurrentHashMap.newKeySet] so reads and writes across the system callback thread
+ * and any observer thread stay race-free.
+ *
  * Registered once at app startup as a Koin singleton; the callback stays alive for the
- * process lifetime. [currentState] is maintained as a `MutableStateFlow`, keeping the
- * synchronous read (used by the HTTP pre-flight check) cheap and allocation-free.
+ * process lifetime. [currentState] is a `MutableStateFlow`, keeping the synchronous
+ * read (used by the HTTP pre-flight check) cheap and allocation-free.
  *
  * Requires `android.permission.ACCESS_NETWORK_STATE` in the manifest.
  */
@@ -27,27 +35,35 @@ internal class AndroidConnectivityMonitor(
     private val connectivityManager: ConnectivityManager =
         context.applicationContext.getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager
 
+    // Thread-safe set of currently validated networks. The callback fires on a system
+    // thread; state observers read from any thread. Publish to [state] after every
+    // mutation so downstream sees a consistent derived value.
+    private val validatedNetworks: MutableSet<Network> = ConcurrentHashMap.newKeySet()
+
     private val state = MutableStateFlow(readInitialState())
 
     private val callback = object : ConnectivityManager.NetworkCallback() {
-        override fun onAvailable(network: Network) {
-            // Availability alone is not enough — wait for capability confirmation below.
-        }
-
         override fun onCapabilitiesChanged(network: Network, capabilities: NetworkCapabilities) {
-            state.value = if (capabilities.isValidated()) {
-                ConnectivityState.Available
+            // The NetworkRequest filters by VALIDATED, but a network can lose that
+            // capability mid-flight (e.g., captive portal detected) — check defensively.
+            if (capabilities.isValidated()) {
+                validatedNetworks.add(network)
             } else {
-                ConnectivityState.Unavailable
+                validatedNetworks.remove(network)
             }
+            publish()
         }
 
         override fun onLost(network: Network) {
-            state.value = ConnectivityState.Unavailable
+            validatedNetworks.remove(network)
+            publish()
         }
 
         override fun onUnavailable() {
-            state.value = ConnectivityState.Unavailable
+            // Terminal: the callback will not fire again. Clear and publish so the
+            // pre-flight check sees Unavailable rather than a stale Available.
+            validatedNetworks.clear()
+            publish()
         }
     }
 
@@ -64,6 +80,16 @@ internal class AndroidConnectivityMonitor(
 
     override fun observe(): Flow<ConnectivityState> = state.asStateFlow()
 
+    private fun publish() {
+        state.value = if (validatedNetworks.isNotEmpty()) {
+            ConnectivityState.Available
+        } else {
+            ConnectivityState.Unavailable
+        }
+    }
+
+    // Seed the state before the callback fires at least once. The callback will then
+    // take over and the set becomes the source of truth.
     private fun readInitialState(): ConnectivityState {
         val active = connectivityManager.activeNetwork ?: return ConnectivityState.Unavailable
         val capabilities = connectivityManager.getNetworkCapabilities(active)

--- a/shared/core/network/impl/src/commonMain/kotlin/com/xbot/network/api/DefaultAdsApi.kt
+++ b/shared/core/network/impl/src/commonMain/kotlin/com/xbot/network/api/DefaultAdsApi.kt
@@ -1,20 +1,19 @@
 package com.xbot.network.api
 
 import arrow.core.Either
-import com.xbot.network.client.NetworkError
-import com.xbot.network.client.request
+import com.xbot.domain.models.DomainError
+import com.xbot.network.client.ResilientHttpRequester
 import com.xbot.network.models.dto.VastDto
-import io.ktor.client.HttpClient
 import io.ktor.client.request.get
 import org.koin.core.annotation.Singleton
 
 @Singleton
-internal class DefaultAdsApi(private val client: HttpClient) : AdsApi {
-    override suspend fun getVasts(): Either<NetworkError, List<VastDto>> = client.request {
+internal class DefaultAdsApi(private val requester: ResilientHttpRequester) : AdsApi {
+    override suspend fun getVasts(): Either<DomainError, List<VastDto>> = requester.request {
         get("ads/vasts")
     }
 
-    override suspend fun getVastsChain(): Either<NetworkError, String> = client.request {
+    override suspend fun getVastsChain(): Either<DomainError, String> = requester.request {
         get("ads/vasts/chain")
     }
 }

--- a/shared/core/network/impl/src/commonMain/kotlin/com/xbot/network/api/DefaultAuthApi.kt
+++ b/shared/core/network/impl/src/commonMain/kotlin/com/xbot/network/api/DefaultAuthApi.kt
@@ -1,15 +1,14 @@
 package com.xbot.network.api
 
 import arrow.core.Either
-import com.xbot.network.client.NetworkError
-import com.xbot.network.client.request
+import com.xbot.domain.models.DomainError
+import com.xbot.network.client.ResilientHttpRequester
 import com.xbot.network.client.requiresAuth
 import com.xbot.network.models.enums.SocialTypeDto
 import com.xbot.network.models.responses.AuthResponse
 import com.xbot.network.models.responses.LoginResponse
 import com.xbot.network.models.responses.LogoutResponse
 import com.xbot.network.models.responses.SocialAuthResponse
-import io.ktor.client.HttpClient
 import io.ktor.client.request.get
 import io.ktor.client.request.parameter
 import io.ktor.client.request.post
@@ -19,34 +18,34 @@ import io.ktor.http.contentType
 import org.koin.core.annotation.Singleton
 
 @Singleton
-internal class DefaultAuthApi(private val client: HttpClient) : AuthApi {
+internal class DefaultAuthApi(private val requester: ResilientHttpRequester) : AuthApi {
     override suspend fun login(
         login: String,
         password: String
-    ): Either<NetworkError, LoginResponse> = client.request {
+    ): Either<DomainError, LoginResponse> = requester.request {
         post("accounts/users/auth/login") {
             contentType(ContentType.Application.Json)
             setBody(mapOf("login" to login, "password" to password))
         }
     }
 
-    override suspend fun logout(): Either<NetworkError, LogoutResponse> = client.request {
+    override suspend fun logout(): Either<DomainError, LogoutResponse> = requester.request {
         post("accounts/users/auth/logout") {
             requiresAuth()
         }
     }
 
-    override suspend fun socialLogin(provider: SocialTypeDto): Either<NetworkError, SocialAuthResponse> = client.request {
+    override suspend fun socialLogin(provider: SocialTypeDto): Either<DomainError, SocialAuthResponse> = requester.request {
         get("accounts/users/auth/social/$provider/login")
     }
 
-    override suspend fun socialAuthenticate(state: String): Either<NetworkError, AuthResponse> = client.request {
+    override suspend fun socialAuthenticate(state: String): Either<DomainError, AuthResponse> = requester.request {
         get("accounts/users/auth/social/authenticate") {
             parameter("state", state)
         }
     }
 
-    override suspend fun forgotPassword(email: String): Either<NetworkError, Unit> = client.request {
+    override suspend fun forgotPassword(email: String): Either<DomainError, Unit> = requester.request {
         get("accounts/users/auth/password/forget") {
             contentType(ContentType.Application.Json)
             setBody(mapOf("email" to email))
@@ -57,7 +56,7 @@ internal class DefaultAuthApi(private val client: HttpClient) : AuthApi {
         token: String,
         password: String,
         passwordConfirmation: String
-    ): Either<NetworkError, Unit> = client.request {
+    ): Either<DomainError, Unit> = requester.request {
         post("accounts/users/auth/password/reset") {
             contentType(ContentType.Application.Json)
             setBody(

--- a/shared/core/network/impl/src/commonMain/kotlin/com/xbot/network/api/DefaultCatalogApi.kt
+++ b/shared/core/network/impl/src/commonMain/kotlin/com/xbot/network/api/DefaultCatalogApi.kt
@@ -1,8 +1,8 @@
 package com.xbot.network.api
 
 import arrow.core.Either
-import com.xbot.network.client.NetworkError
-import com.xbot.network.client.request
+import com.xbot.domain.models.DomainError
+import com.xbot.network.client.ResilientHttpRequester
 import com.xbot.network.models.dto.GenreDto
 import com.xbot.network.models.dto.ReleaseDto
 import com.xbot.network.models.enums.AgeRatingDto
@@ -12,13 +12,12 @@ import com.xbot.network.models.enums.ReleaseTypeDto
 import com.xbot.network.models.enums.SeasonDto
 import com.xbot.network.models.enums.SortingTypeDto
 import com.xbot.network.models.responses.PaginatedResponse
-import io.ktor.client.HttpClient
 import io.ktor.client.request.get
 import io.ktor.client.request.parameter
 import org.koin.core.annotation.Singleton
 
 @Singleton
-internal class DefaultCatalogApi(private val client: HttpClient) : CatalogApi {
+internal class DefaultCatalogApi(private val requester: ResilientHttpRequester) : CatalogApi {
     override suspend fun getCatalogReleases(
         page: Int,
         limit: Int,
@@ -32,7 +31,7 @@ internal class DefaultCatalogApi(private val client: HttpClient) : CatalogApi {
         ageRatings: List<AgeRatingDto>?,
         publishStatuses: List<PublishStatusDto>?,
         productionStatuses: List<ProductionStatusDto>?
-    ): Either<NetworkError, PaginatedResponse<ReleaseDto>> = client.request {
+    ): Either<DomainError, PaginatedResponse<ReleaseDto>> = requester.request {
         get("anime/catalog/releases") {
             parameter("page", page)
             parameter("limit", limit)
@@ -49,35 +48,35 @@ internal class DefaultCatalogApi(private val client: HttpClient) : CatalogApi {
         }
     }
 
-    override suspend fun getCatalogAgeRatings(): Either<NetworkError, List<AgeRatingDto>> = client.request {
+    override suspend fun getCatalogAgeRatings(): Either<DomainError, List<AgeRatingDto>> = requester.request {
         get("anime/catalog/references/age-ratings")
     }
 
-    override suspend fun getCatalogGenres(): Either<NetworkError, List<GenreDto>> = client.request {
+    override suspend fun getCatalogGenres(): Either<DomainError, List<GenreDto>> = requester.request {
         get("anime/catalog/references/genres")
     }
 
-    override suspend fun getCatalogProductionStatuses(): Either<NetworkError, List<ProductionStatusDto>> = client.request {
+    override suspend fun getCatalogProductionStatuses(): Either<DomainError, List<ProductionStatusDto>> = requester.request {
         get("anime/catalog/references/production-statuses")
     }
 
-    override suspend fun getCatalogPublishStatuses(): Either<NetworkError, List<PublishStatusDto>> = client.request {
+    override suspend fun getCatalogPublishStatuses(): Either<DomainError, List<PublishStatusDto>> = requester.request {
         get("anime/catalog/references/publish-statuses")
     }
 
-    override suspend fun getCatalogSeasons(): Either<NetworkError, List<SeasonDto>> = client.request {
+    override suspend fun getCatalogSeasons(): Either<DomainError, List<SeasonDto>> = requester.request {
         get("anime/catalog/references/seasons")
     }
 
-    override suspend fun getCatalogSortingTypes(): Either<NetworkError, List<SortingTypeDto>> = client.request {
+    override suspend fun getCatalogSortingTypes(): Either<DomainError, List<SortingTypeDto>> = requester.request {
         get("anime/catalog/references/sorting")
     }
 
-    override suspend fun getCatalogReleaseTypes(): Either<NetworkError, List<ReleaseTypeDto>> = client.request {
+    override suspend fun getCatalogReleaseTypes(): Either<DomainError, List<ReleaseTypeDto>> = requester.request {
         get("anime/catalog/references/types")
     }
 
-    override suspend fun getCatalogYears(): Either<NetworkError, List<Int>> = client.request {
+    override suspend fun getCatalogYears(): Either<DomainError, List<Int>> = requester.request {
         get("anime/catalog/references/years")
     }
 }

--- a/shared/core/network/impl/src/commonMain/kotlin/com/xbot/network/api/DefaultCollectionApi.kt
+++ b/shared/core/network/impl/src/commonMain/kotlin/com/xbot/network/api/DefaultCollectionApi.kt
@@ -1,8 +1,8 @@
 package com.xbot.network.api
 
 import arrow.core.Either
-import com.xbot.network.client.NetworkError
-import com.xbot.network.client.request
+import com.xbot.domain.models.DomainError
+import com.xbot.network.client.ResilientHttpRequester
 import com.xbot.network.client.requiresAuth
 import com.xbot.network.models.dto.GenreDto
 import com.xbot.network.models.dto.ReleaseDto
@@ -10,7 +10,6 @@ import com.xbot.network.models.enums.AgeRatingDto
 import com.xbot.network.models.enums.CollectionTypeDto
 import com.xbot.network.models.enums.ReleaseTypeDto
 import com.xbot.network.models.responses.PaginatedResponse
-import io.ktor.client.HttpClient
 import io.ktor.client.request.delete
 import io.ktor.client.request.get
 import io.ktor.client.request.parameter
@@ -19,8 +18,8 @@ import io.ktor.client.request.setBody
 import org.koin.core.annotation.Singleton
 
 @Singleton
-internal class DefaultCollectionApi(private val client: HttpClient) : CollectionApi {
-    override suspend fun getCollectionIds(): Either<NetworkError, Map<Int, CollectionTypeDto>> = client.request {
+internal class DefaultCollectionApi(private val requester: ResilientHttpRequester) : CollectionApi {
+    override suspend fun getCollectionIds(): Either<DomainError, Map<Int, CollectionTypeDto>> = requester.request {
         get("accounts/users/me/collections/ids") {
             requiresAuth()
         }
@@ -35,7 +34,7 @@ internal class DefaultCollectionApi(private val client: HttpClient) : Collection
         years: List<Int>?,
         search: String?,
         ageRatings: List<AgeRatingDto>?
-    ): Either<NetworkError, PaginatedResponse<ReleaseDto>> = client.request {
+    ): Either<DomainError, PaginatedResponse<ReleaseDto>> = requester.request {
         get("accounts/users/me/collections/releases") {
             requiresAuth()
             parameter("page", page)
@@ -49,7 +48,7 @@ internal class DefaultCollectionApi(private val client: HttpClient) : Collection
         }
     }
 
-    override suspend fun addToCollections(collections: Map<Int, CollectionTypeDto>): Either<NetworkError, Map<Int, CollectionTypeDto>> = client.request {
+    override suspend fun addToCollections(collections: Map<Int, CollectionTypeDto>): Either<DomainError, Map<Int, CollectionTypeDto>> = requester.request {
         post("accounts/users/me/collections") {
             requiresAuth()
             setBody(collections.map { (releaseId, collectionType) ->
@@ -61,32 +60,32 @@ internal class DefaultCollectionApi(private val client: HttpClient) : Collection
         }
     }
 
-    override suspend fun removeFromCollections(releaseIds: List<Int>): Either<NetworkError, Map<Int, CollectionTypeDto>> = client.request {
+    override suspend fun removeFromCollections(releaseIds: List<Int>): Either<DomainError, Map<Int, CollectionTypeDto>> = requester.request {
         delete("accounts/users/me/collections") {
             requiresAuth()
             setBody(releaseIds.map { mapOf("release_id" to it) })
         }
     }
 
-    override suspend fun getCollectionAgeRatings(): Either<NetworkError, List<AgeRatingDto>> = client.request {
+    override suspend fun getCollectionAgeRatings(): Either<DomainError, List<AgeRatingDto>> = requester.request {
         get("accounts/users/me/collections/references/age-ratings") {
             requiresAuth()
         }
     }
 
-    override suspend fun getCollectionGenres(): Either<NetworkError, List<GenreDto>> = client.request {
+    override suspend fun getCollectionGenres(): Either<DomainError, List<GenreDto>> = requester.request {
         get("accounts/users/me/collections/references/genres") {
             requiresAuth()
         }
     }
 
-    override suspend fun getCollectionReleaseTypes(): Either<NetworkError, List<ReleaseTypeDto>> = client.request {
+    override suspend fun getCollectionReleaseTypes(): Either<DomainError, List<ReleaseTypeDto>> = requester.request {
         get("accounts/users/me/collections/references/types") {
             requiresAuth()
         }
     }
 
-    override suspend fun getCollectionYears(): Either<NetworkError, List<Int>> = client.request {
+    override suspend fun getCollectionYears(): Either<DomainError, List<Int>> = requester.request {
         get("accounts/users/me/collections/references/years") {
             requiresAuth()
         }

--- a/shared/core/network/impl/src/commonMain/kotlin/com/xbot/network/api/DefaultEpisodesApi.kt
+++ b/shared/core/network/impl/src/commonMain/kotlin/com/xbot/network/api/DefaultEpisodesApi.kt
@@ -1,21 +1,20 @@
 package com.xbot.network.api
 
 import arrow.core.Either
-import com.xbot.network.client.NetworkError
-import com.xbot.network.client.request
+import com.xbot.domain.models.DomainError
+import com.xbot.network.client.ResilientHttpRequester
 import com.xbot.network.models.dto.EpisodeTimecodeDto
 import com.xbot.network.models.dto.EpisodeWithReleaseDto
-import io.ktor.client.HttpClient
 import io.ktor.client.request.get
 import org.koin.core.annotation.Singleton
 
 @Singleton
-internal class DefaultEpisodesApi(private val client: HttpClient) : EpisodesApi {
-    override suspend fun getEpisode(episodeId: Int): Either<NetworkError, EpisodeWithReleaseDto> = client.request {
+internal class DefaultEpisodesApi(private val requester: ResilientHttpRequester) : EpisodesApi {
+    override suspend fun getEpisode(episodeId: Int): Either<DomainError, EpisodeWithReleaseDto> = requester.request {
         get("anime/releases/episodes/${episodeId}")
     }
 
-    override suspend fun getEpisodeTimecode(releaseEpisodeId: String): Either<NetworkError, EpisodeTimecodeDto> = client.request {
+    override suspend fun getEpisodeTimecode(releaseEpisodeId: String): Either<DomainError, EpisodeTimecodeDto> = requester.request {
         get("anime/releases/episodes/${releaseEpisodeId}/timecode")
     }
 }

--- a/shared/core/network/impl/src/commonMain/kotlin/com/xbot/network/api/DefaultFavoritesApi.kt
+++ b/shared/core/network/impl/src/commonMain/kotlin/com/xbot/network/api/DefaultFavoritesApi.kt
@@ -1,8 +1,8 @@
 package com.xbot.network.api
 
 import arrow.core.Either
-import com.xbot.network.client.NetworkError
-import com.xbot.network.client.request
+import com.xbot.domain.models.DomainError
+import com.xbot.network.client.ResilientHttpRequester
 import com.xbot.network.client.requiresAuth
 import com.xbot.network.models.dto.GenreDto
 import com.xbot.network.models.dto.ReleaseDto
@@ -11,7 +11,6 @@ import com.xbot.network.models.enums.FavoriteSortingTypeDto
 import com.xbot.network.models.enums.ReleaseTypeDto
 import com.xbot.network.models.enums.SortingTypeDto
 import com.xbot.network.models.responses.PaginatedResponse
-import io.ktor.client.HttpClient
 import io.ktor.client.request.delete
 import io.ktor.client.request.get
 import io.ktor.client.request.parameter
@@ -20,8 +19,8 @@ import io.ktor.client.request.setBody
 import org.koin.core.annotation.Singleton
 
 @Singleton
-internal class DefaultFavoritesApi(private val client: HttpClient) : FavoritesApi {
-    override suspend fun getFavoriteIds(): Either<NetworkError, List<Int>> = client.request {
+internal class DefaultFavoritesApi(private val requester: ResilientHttpRequester) : FavoritesApi {
+    override suspend fun getFavoriteIds(): Either<DomainError, List<Int>> = requester.request {
         get("accounts/users/me/favorites/ids") {
             requiresAuth()
         }
@@ -36,7 +35,7 @@ internal class DefaultFavoritesApi(private val client: HttpClient) : FavoritesAp
         search: String?,
         sorting: SortingTypeDto?,
         ageRatings: List<AgeRatingDto>?
-    ): Either<NetworkError, PaginatedResponse<ReleaseDto>> = client.request {
+    ): Either<DomainError, PaginatedResponse<ReleaseDto>> = requester.request {
         get("accounts/users/me/favorites/releases") {
             requiresAuth()
             parameter("page", page)
@@ -52,7 +51,7 @@ internal class DefaultFavoritesApi(private val client: HttpClient) : FavoritesAp
 
     override suspend fun addToFavorites(
         releaseIds: List<Int>
-    ): Either<NetworkError, List<Int>> = client.request {
+    ): Either<DomainError, List<Int>> = requester.request {
         post("accounts/users/me/favorites") {
             requiresAuth()
             setBody(releaseIds.map { mapOf("release_id" to it) })
@@ -61,38 +60,38 @@ internal class DefaultFavoritesApi(private val client: HttpClient) : FavoritesAp
 
     override suspend fun removeFromFavorites(
         releaseIds: List<Int>
-    ): Either<NetworkError, List<Int>> = client.request {
+    ): Either<DomainError, List<Int>> = requester.request {
         delete("accounts/users/me/favorites") {
             requiresAuth()
             setBody(releaseIds.map { mapOf("release_id" to it) })
         }
     }
 
-    override suspend fun getFavoriteAgeRatings(): Either<NetworkError, List<AgeRatingDto>> = client.request {
+    override suspend fun getFavoriteAgeRatings(): Either<DomainError, List<AgeRatingDto>> = requester.request {
         get("accounts/users/me/favorites/references/age-ratings") {
             requiresAuth()
         }
     }
 
-    override suspend fun getFavoriteGenres(): Either<NetworkError, List<GenreDto>> = client.request {
+    override suspend fun getFavoriteGenres(): Either<DomainError, List<GenreDto>> = requester.request {
         get("accounts/users/me/favorites/references/genres") {
             requiresAuth()
         }
     }
 
-    override suspend fun getFavoriteSortingTypes(): Either<NetworkError, List<FavoriteSortingTypeDto>> = client.request {
+    override suspend fun getFavoriteSortingTypes(): Either<DomainError, List<FavoriteSortingTypeDto>> = requester.request {
         get("accounts/users/me/favorites/references/sorting") {
             requiresAuth()
         }
     }
 
-    override suspend fun getFavoriteReleaseTypes(): Either<NetworkError, List<ReleaseTypeDto>> = client.request {
+    override suspend fun getFavoriteReleaseTypes(): Either<DomainError, List<ReleaseTypeDto>> = requester.request {
         get("accounts/users/me/favorites/references/types") {
             requiresAuth()
         }
     }
 
-    override suspend fun getFavoriteYears(): Either<NetworkError, List<Int>> = client.request {
+    override suspend fun getFavoriteYears(): Either<DomainError, List<Int>> = requester.request {
         get("accounts/users/me/favorites/references/years") {
             requiresAuth()
         }

--- a/shared/core/network/impl/src/commonMain/kotlin/com/xbot/network/api/DefaultFranchisesApi.kt
+++ b/shared/core/network/impl/src/commonMain/kotlin/com/xbot/network/api/DefaultFranchisesApi.kt
@@ -1,31 +1,30 @@
 package com.xbot.network.api
 
 import arrow.core.Either
-import com.xbot.network.client.NetworkError
-import com.xbot.network.client.request
+import com.xbot.domain.models.DomainError
+import com.xbot.network.client.ResilientHttpRequester
 import com.xbot.network.models.dto.FranchiseDto
-import io.ktor.client.HttpClient
 import io.ktor.client.request.get
 import io.ktor.client.request.parameter
 import org.koin.core.annotation.Singleton
 
 @Singleton
-internal class DefaultFranchisesApi(private val client: HttpClient) : FranchisesApi {
-    override suspend fun getFranchises(): Either<NetworkError, List<FranchiseDto>> = client.request {
+internal class DefaultFranchisesApi(private val requester: ResilientHttpRequester) : FranchisesApi {
+    override suspend fun getFranchises(): Either<DomainError, List<FranchiseDto>> = requester.request {
         get("anime/franchises")
     }
 
-    override suspend fun getFranchise(franchiseId: String): Either<NetworkError, FranchiseDto> = client.request {
+    override suspend fun getFranchise(franchiseId: String): Either<DomainError, FranchiseDto> = requester.request {
         get("anime/franchises/${franchiseId}")
     }
 
-    override suspend fun getFranchisesRandom(limit: Int): Either<NetworkError, List<FranchiseDto>> = client.request {
+    override suspend fun getFranchisesRandom(limit: Int): Either<DomainError, List<FranchiseDto>> = requester.request {
         get("anime/franchises/random") {
             parameter("limit", limit)
         }
     }
 
-    override suspend fun getFranchisesByRelease(releaseId: Int): Either<NetworkError, List<FranchiseDto>> = client.request {
+    override suspend fun getFranchisesByRelease(releaseId: Int): Either<DomainError, List<FranchiseDto>> = requester.request {
         get("anime/franchises/release/${releaseId}")
     }
 

--- a/shared/core/network/impl/src/commonMain/kotlin/com/xbot/network/api/DefaultGenresApi.kt
+++ b/shared/core/network/impl/src/commonMain/kotlin/com/xbot/network/api/DefaultGenresApi.kt
@@ -1,27 +1,26 @@
 package com.xbot.network.api
 
 import arrow.core.Either
-import com.xbot.network.client.NetworkError
-import com.xbot.network.client.request
+import com.xbot.domain.models.DomainError
+import com.xbot.network.client.ResilientHttpRequester
 import com.xbot.network.models.dto.GenreDto
 import com.xbot.network.models.dto.ReleaseDto
 import com.xbot.network.models.responses.PaginatedResponse
-import io.ktor.client.HttpClient
 import io.ktor.client.request.get
 import io.ktor.client.request.parameter
 import org.koin.core.annotation.Singleton
 
 @Singleton
-internal class DefaultGenresApi(private val client: HttpClient) : GenresApi {
-    override suspend fun getGenres(): Either<NetworkError, List<GenreDto>> = client.request {
+internal class DefaultGenresApi(private val requester: ResilientHttpRequester) : GenresApi {
+    override suspend fun getGenres(): Either<DomainError, List<GenreDto>> = requester.request {
         get("anime/genres")
     }
 
-    override suspend fun getGenre(genreId: Int): Either<NetworkError, GenreDto> = client.request {
+    override suspend fun getGenre(genreId: Int): Either<DomainError, GenreDto> = requester.request {
         get("anime/genres/$genreId")
     }
 
-    override suspend fun getRandomGenres(limit: Int): Either<NetworkError, List<GenreDto>> = client.request {
+    override suspend fun getRandomGenres(limit: Int): Either<DomainError, List<GenreDto>> = requester.request {
         get("anime/genres/random") {
             parameter("limit", limit)
         }
@@ -31,7 +30,7 @@ internal class DefaultGenresApi(private val client: HttpClient) : GenresApi {
         genreId: Int,
         page: Int,
         limit: Int
-    ): Either<NetworkError, PaginatedResponse<ReleaseDto>> = client.request {
+    ): Either<DomainError, PaginatedResponse<ReleaseDto>> = requester.request {
         get("anime/genres/$genreId/releases") {
             parameter("page", page)
             parameter("limit", limit)

--- a/shared/core/network/impl/src/commonMain/kotlin/com/xbot/network/api/DefaultOtpApi.kt
+++ b/shared/core/network/impl/src/commonMain/kotlin/com/xbot/network/api/DefaultOtpApi.kt
@@ -1,11 +1,10 @@
 package com.xbot.network.api
 
 import arrow.core.Either
-import com.xbot.network.client.NetworkError
-import com.xbot.network.client.request
+import com.xbot.domain.models.DomainError
+import com.xbot.network.client.ResilientHttpRequester
 import com.xbot.network.models.responses.LoginResponse
 import com.xbot.network.models.responses.OtpResponse
-import io.ktor.client.HttpClient
 import io.ktor.client.request.post
 import io.ktor.client.request.setBody
 import io.ktor.http.ContentType
@@ -13,15 +12,15 @@ import io.ktor.http.contentType
 import org.koin.core.annotation.Singleton
 
 @Singleton
-internal class DefaultOtpApi(private val client: HttpClient) : OtpApi {
-    override suspend fun getOtp(deviceId: String): Either<NetworkError, OtpResponse> = client.request {
+internal class DefaultOtpApi(private val requester: ResilientHttpRequester) : OtpApi {
+    override suspend fun getOtp(deviceId: String): Either<DomainError, OtpResponse> = requester.request {
         post("accounts/otp/get") {
             contentType(ContentType.Application.Json)
             setBody(mapOf("device_id" to deviceId))
         }
     }
 
-    override suspend fun acceptOtp(code: Int): Either<NetworkError, Unit> = client.request {
+    override suspend fun acceptOtp(code: Int): Either<DomainError, Unit> = requester.request {
         post("accounts/otp/accept") {
             contentType(ContentType.Application.Json)
             setBody(mapOf("code" to code))
@@ -31,7 +30,7 @@ internal class DefaultOtpApi(private val client: HttpClient) : OtpApi {
     override suspend fun loginWithOtp(
         code: Int,
         deviceId: String
-    ): Either<NetworkError, LoginResponse> = client.request {
+    ): Either<DomainError, LoginResponse> = requester.request {
         post("accounts/otp/login") {
             contentType(ContentType.Application.Json)
             setBody(

--- a/shared/core/network/impl/src/commonMain/kotlin/com/xbot/network/api/DefaultProfileApi.kt
+++ b/shared/core/network/impl/src/commonMain/kotlin/com/xbot/network/api/DefaultProfileApi.kt
@@ -1,17 +1,16 @@
 package com.xbot.network.api
 
 import arrow.core.Either
-import com.xbot.network.client.NetworkError
-import com.xbot.network.client.request
+import com.xbot.domain.models.DomainError
+import com.xbot.network.client.ResilientHttpRequester
 import com.xbot.network.client.requiresAuth
 import com.xbot.network.models.dto.ProfileDto
-import io.ktor.client.HttpClient
 import io.ktor.client.request.get
 import org.koin.core.annotation.Singleton
 
 @Singleton
-internal class DefaultProfileApi(private val client: HttpClient) : ProfileApi {
-    override suspend fun getProfile(): Either<NetworkError, ProfileDto> = client.request {
+internal class DefaultProfileApi(private val requester: ResilientHttpRequester) : ProfileApi {
+    override suspend fun getProfile(): Either<DomainError, ProfileDto> = requester.request {
         get("accounts/users/me/profile") {
             requiresAuth()
         }

--- a/shared/core/network/impl/src/commonMain/kotlin/com/xbot/network/api/DefaultPromotionsApi.kt
+++ b/shared/core/network/impl/src/commonMain/kotlin/com/xbot/network/api/DefaultPromotionsApi.kt
@@ -1,16 +1,15 @@
 package com.xbot.network.api
 
 import arrow.core.Either
-import com.xbot.network.client.NetworkError
-import com.xbot.network.client.request
+import com.xbot.domain.models.DomainError
+import com.xbot.network.client.ResilientHttpRequester
 import com.xbot.network.models.dto.PromotionDto
-import io.ktor.client.HttpClient
 import io.ktor.client.request.get
 import org.koin.core.annotation.Singleton
 
 @Singleton
-internal class DefaultPromotionsApi(private val client: HttpClient) : PromotionsApi {
-    override suspend fun getPromotions(): Either<NetworkError, List<PromotionDto>> = client.request {
+internal class DefaultPromotionsApi(private val requester: ResilientHttpRequester) : PromotionsApi {
+    override suspend fun getPromotions(): Either<DomainError, List<PromotionDto>> = requester.request {
         get("media/promotions")
     }
 }

--- a/shared/core/network/impl/src/commonMain/kotlin/com/xbot/network/api/DefaultReleasesApi.kt
+++ b/shared/core/network/impl/src/commonMain/kotlin/com/xbot/network/api/DefaultReleasesApi.kt
@@ -1,26 +1,25 @@
 package com.xbot.network.api
 
 import arrow.core.Either
-import com.xbot.network.client.NetworkError
-import com.xbot.network.client.request
+import com.xbot.domain.models.DomainError
+import com.xbot.network.client.ResilientHttpRequester
 import com.xbot.network.models.dto.EpisodeTimecodeDto
 import com.xbot.network.models.dto.ReleaseDto
 import com.xbot.network.models.dto.ReleaseMemberDto
 import com.xbot.network.models.responses.PaginatedResponse
-import io.ktor.client.HttpClient
 import io.ktor.client.request.get
 import io.ktor.client.request.parameter
 import org.koin.core.annotation.Singleton
 
 @Singleton
-internal class DefaultReleasesApi(private val client: HttpClient) : ReleasesApi {
-    override suspend fun getLatestReleases(limit: Int): Either<NetworkError, List<ReleaseDto>> = client.request {
+internal class DefaultReleasesApi(private val requester: ResilientHttpRequester) : ReleasesApi {
+    override suspend fun getLatestReleases(limit: Int): Either<DomainError, List<ReleaseDto>> = requester.request {
         get("anime/releases/latest") {
             parameter("limit", limit)
         }
     }
 
-    override suspend fun getRandomReleases(limit: Int): Either<NetworkError, List<ReleaseDto>> = client.request {
+    override suspend fun getRandomReleases(limit: Int): Either<DomainError, List<ReleaseDto>> = requester.request {
         get("anime/releases/random") {
             parameter("limit", limit)
         }
@@ -31,7 +30,7 @@ internal class DefaultReleasesApi(private val client: HttpClient) : ReleasesApi 
         aliases: List<String>?,
         page: Int,
         limit: Int
-    ): Either<NetworkError, PaginatedResponse<ReleaseDto>> = client.request {
+    ): Either<DomainError, PaginatedResponse<ReleaseDto>> = requester.request {
         get("anime/releases/list") {
             parameter("page", page)
             parameter("limit", limit)
@@ -40,15 +39,15 @@ internal class DefaultReleasesApi(private val client: HttpClient) : ReleasesApi 
         }
     }
 
-    override suspend fun getRelease(aliasOrId: String): Either<NetworkError, ReleaseDto> = client.request {
+    override suspend fun getRelease(aliasOrId: String): Either<DomainError, ReleaseDto> = requester.request {
         get("anime/releases/${aliasOrId}")
     }
 
-    override suspend fun getReleaseMembers(aliasOrId: String): Either<NetworkError, List<ReleaseMemberDto>> = client.request {
+    override suspend fun getReleaseMembers(aliasOrId: String): Either<DomainError, List<ReleaseMemberDto>> = requester.request {
         get("anime/releases/$aliasOrId/members")
     }
 
-    override suspend fun getReleaseEpisodesTimecodes(aliasOrId: String): Either<NetworkError, List<EpisodeTimecodeDto>> = client.request {
+    override suspend fun getReleaseEpisodesTimecodes(aliasOrId: String): Either<DomainError, List<EpisodeTimecodeDto>> = requester.request {
         get("anime/releases/$aliasOrId/episodes/timecodes")
     }
 }

--- a/shared/core/network/impl/src/commonMain/kotlin/com/xbot/network/api/DefaultScheduleApi.kt
+++ b/shared/core/network/impl/src/commonMain/kotlin/com/xbot/network/api/DefaultScheduleApi.kt
@@ -1,20 +1,19 @@
 package com.xbot.network.api
 
 import arrow.core.Either
-import com.xbot.network.client.NetworkError
-import com.xbot.network.client.request
+import com.xbot.domain.models.DomainError
+import com.xbot.network.client.ResilientHttpRequester
 import com.xbot.network.models.dto.ScheduleDto
-import io.ktor.client.HttpClient
 import io.ktor.client.request.get
 import org.koin.core.annotation.Singleton
 
 @Singleton
-internal class DefaultScheduleApi(private val client: HttpClient) : ScheduleApi {
-    override suspend fun getScheduleNow(): Either<NetworkError, Map<String, List<ScheduleDto>>> = client.request {
+internal class DefaultScheduleApi(private val requester: ResilientHttpRequester) : ScheduleApi {
+    override suspend fun getScheduleNow(): Either<DomainError, Map<String, List<ScheduleDto>>> = requester.request {
         get("anime/schedule/now")
     }
 
-    override suspend fun getScheduleWeek(): Either<NetworkError, List<ScheduleDto>> = client.request {
+    override suspend fun getScheduleWeek(): Either<DomainError, List<ScheduleDto>> = requester.request {
         get("anime/schedule/week")
     }
 }

--- a/shared/core/network/impl/src/commonMain/kotlin/com/xbot/network/api/DefaultSearchApi.kt
+++ b/shared/core/network/impl/src/commonMain/kotlin/com/xbot/network/api/DefaultSearchApi.kt
@@ -1,17 +1,16 @@
 package com.xbot.network.api
 
 import arrow.core.Either
-import com.xbot.network.client.NetworkError
-import com.xbot.network.client.request
+import com.xbot.domain.models.DomainError
+import com.xbot.network.client.ResilientHttpRequester
 import com.xbot.network.models.dto.ReleaseDto
-import io.ktor.client.HttpClient
 import io.ktor.client.request.get
 import io.ktor.client.request.parameter
 import org.koin.core.annotation.Singleton
 
 @Singleton
-internal class DefaultSearchApi(private val client: HttpClient) : SearchApi {
-    override suspend fun searchReleases(query: String): Either<NetworkError, List<ReleaseDto>> = client.request {
+internal class DefaultSearchApi(private val requester: ResilientHttpRequester) : SearchApi {
+    override suspend fun searchReleases(query: String): Either<DomainError, List<ReleaseDto>> = requester.request {
         get("app/search/releases") {
             parameter("query", query)
         }

--- a/shared/core/network/impl/src/commonMain/kotlin/com/xbot/network/api/DefaultTeamsApi.kt
+++ b/shared/core/network/impl/src/commonMain/kotlin/com/xbot/network/api/DefaultTeamsApi.kt
@@ -1,26 +1,25 @@
 package com.xbot.network.api
 
 import arrow.core.Either
-import com.xbot.network.client.NetworkError
-import com.xbot.network.client.request
+import com.xbot.domain.models.DomainError
+import com.xbot.network.client.ResilientHttpRequester
 import com.xbot.network.models.dto.TeamDto
 import com.xbot.network.models.dto.TeamRoleDto
 import com.xbot.network.models.dto.TeamUserApi
-import io.ktor.client.HttpClient
 import io.ktor.client.request.get
 import org.koin.core.annotation.Singleton
 
 @Singleton
-internal class DefaultTeamsApi(private val client: HttpClient) : TeamsApi {
-    override suspend fun getTeams(): Either<NetworkError, List<TeamDto>> = client.request {
+internal class DefaultTeamsApi(private val requester: ResilientHttpRequester) : TeamsApi {
+    override suspend fun getTeams(): Either<DomainError, List<TeamDto>> = requester.request {
         get("teams/")
     }
 
-    override suspend fun getTeamRoles(): Either<NetworkError, List<TeamRoleDto>> = client.request {
+    override suspend fun getTeamRoles(): Either<DomainError, List<TeamRoleDto>> = requester.request {
         get("teams/roles")
     }
 
-    override suspend fun getTeamUsers(): Either<NetworkError, List<TeamUserApi>> = client.request {
+    override suspend fun getTeamUsers(): Either<DomainError, List<TeamUserApi>> = requester.request {
         get("teams/users")
     }
 }

--- a/shared/core/network/impl/src/commonMain/kotlin/com/xbot/network/api/DefaultTorrentsApi.kt
+++ b/shared/core/network/impl/src/commonMain/kotlin/com/xbot/network/api/DefaultTorrentsApi.kt
@@ -1,48 +1,47 @@
 package com.xbot.network.api
 
 import arrow.core.Either
-import com.xbot.network.client.NetworkError
-import com.xbot.network.client.request
+import com.xbot.domain.models.DomainError
+import com.xbot.network.client.ResilientHttpRequester
 import com.xbot.network.models.dto.TorrentDto
 import com.xbot.network.models.responses.PaginatedResponse
-import io.ktor.client.HttpClient
 import io.ktor.client.request.get
 import io.ktor.client.request.parameter
 import org.koin.core.annotation.Singleton
 
 @Singleton
-internal class DefaultTorrentsApi(private val client: HttpClient) : TorrentsApi {
+internal class DefaultTorrentsApi(private val requester: ResilientHttpRequester) : TorrentsApi {
     override suspend fun getTorrents(
         page: Int,
         limit: Int
-    ): Either<NetworkError, PaginatedResponse<TorrentDto>> = client.request {
+    ): Either<DomainError, PaginatedResponse<TorrentDto>> = requester.request {
         get("anime/torrents") {
             parameter("page", page)
             parameter("limit", limit)
         }
     }
 
-    override suspend fun getTorrent(hashOrId: String): Either<NetworkError, TorrentDto> = client.request {
+    override suspend fun getTorrent(hashOrId: String): Either<DomainError, TorrentDto> = requester.request {
         get("anime/torrents/$hashOrId")
     }
 
     override suspend fun getTorrentFile(
         hashOrId: String,
         pk: String?
-    ): Either<NetworkError, ByteArray> = client.request {
+    ): Either<DomainError, ByteArray> = requester.request {
         get("anime/torrents/$hashOrId/file") {
             pk?.let { parameter("pk", it) }
         }
     }
 
-    override suspend fun getReleaseTorrents(releaseId: Int): Either<NetworkError, List<TorrentDto>> = client.request {
+    override suspend fun getReleaseTorrents(releaseId: Int): Either<DomainError, List<TorrentDto>> = requester.request {
         get("anime/torrents/release/$releaseId")
     }
 
     override suspend fun getTorrentsRss(
         limit: Int?,
         pk: String?
-    ): Either<NetworkError, String> = client.request {
+    ): Either<DomainError, String> = requester.request {
         get("anime/torrents/rss") {
             limit?.let { parameter("limit", it) }
             pk?.let { parameter("pk", it) }
@@ -52,7 +51,7 @@ internal class DefaultTorrentsApi(private val client: HttpClient) : TorrentsApi 
     override suspend fun getReleaseTorrentsRss(
         releaseId: Int,
         pk: String?
-    ): Either<NetworkError, String> = client.request {
+    ): Either<DomainError, String> = requester.request {
         get("anime/torrents/rss/release/$releaseId") {
             pk?.let { parameter("pk", it) }
         }

--- a/shared/core/network/impl/src/commonMain/kotlin/com/xbot/network/api/DefaultVideosApi.kt
+++ b/shared/core/network/impl/src/commonMain/kotlin/com/xbot/network/api/DefaultVideosApi.kt
@@ -1,17 +1,16 @@
 package com.xbot.network.api
 
 import arrow.core.Either
-import com.xbot.network.client.NetworkError
-import com.xbot.network.client.request
+import com.xbot.domain.models.DomainError
+import com.xbot.network.client.ResilientHttpRequester
 import com.xbot.network.models.dto.VideoDto
-import io.ktor.client.HttpClient
 import io.ktor.client.request.get
 import io.ktor.client.request.parameter
 import org.koin.core.annotation.Singleton
 
 @Singleton
-internal class DefaultVideosApi(private val client: HttpClient) : VideosApi {
-    override suspend fun getVideos(limit: Int): Either<NetworkError, List<VideoDto>> = client.request {
+internal class DefaultVideosApi(private val requester: ResilientHttpRequester) : VideosApi {
+    override suspend fun getVideos(limit: Int): Either<DomainError, List<VideoDto>> = requester.request {
         get("media/videos") {
             parameter("limit", limit)
         }

--- a/shared/core/network/impl/src/commonMain/kotlin/com/xbot/network/api/DefaultViewsApi.kt
+++ b/shared/core/network/impl/src/commonMain/kotlin/com/xbot/network/api/DefaultViewsApi.kt
@@ -1,11 +1,10 @@
 package com.xbot.network.api
 
 import arrow.core.Either
-import com.xbot.network.client.NetworkError
-import com.xbot.network.client.request
+import com.xbot.domain.models.DomainError
+import com.xbot.network.client.ResilientHttpRequester
 import com.xbot.network.client.requiresAuth
 import com.xbot.network.models.dto.TimecodeApi
-import io.ktor.client.HttpClient
 import io.ktor.client.request.delete
 import io.ktor.client.request.get
 import io.ktor.client.request.post
@@ -13,8 +12,8 @@ import io.ktor.client.request.setBody
 import org.koin.core.annotation.Singleton
 
 @Singleton
-internal class DefaultViewsApi(private val client: HttpClient) : ViewsApi {
-    override suspend fun getTimecodes(): Either<NetworkError, List<TimecodeApi>> = client.request {
+internal class DefaultViewsApi(private val requester: ResilientHttpRequester) : ViewsApi {
+    override suspend fun getTimecodes(): Either<DomainError, List<TimecodeApi>> = requester.request {
         get("accounts/users/me/views/timecodes") {
             requiresAuth()
         }
@@ -22,7 +21,7 @@ internal class DefaultViewsApi(private val client: HttpClient) : ViewsApi {
 
     override suspend fun updateTimecodes(
         timecodes: List<ViewsApi.UpdateTimecodesRequest>
-    ): Either<NetworkError, List<TimecodeApi>> = client.request {
+    ): Either<DomainError, List<TimecodeApi>> = requester.request {
         post("accounts/users/me/views/timecodes") {
             requiresAuth()
             setBody(timecodes.map { (episodeId, time, isWatched) ->
@@ -37,7 +36,7 @@ internal class DefaultViewsApi(private val client: HttpClient) : ViewsApi {
 
     override suspend fun deleteTimecodes(
         episodeIds: List<String>
-    ): Either<NetworkError, List<TimecodeApi>> = client.request {
+    ): Either<DomainError, List<TimecodeApi>> = requester.request {
         delete("accounts/users/me/views/timecodes") {
             requiresAuth()
             setBody(episodeIds.map { mapOf("release_episode_id" to it) })

--- a/shared/core/network/impl/src/commonMain/kotlin/com/xbot/network/client/HttpClientExtensions.kt
+++ b/shared/core/network/impl/src/commonMain/kotlin/com/xbot/network/client/HttpClientExtensions.kt
@@ -3,8 +3,10 @@ package com.xbot.network.client
 import arrow.core.Either
 import arrow.core.left
 import arrow.core.right
+import com.xbot.domain.models.DomainError
 import io.ktor.client.HttpClient
 import io.ktor.client.call.body
+import io.ktor.client.plugins.HttpRequestTimeoutException
 import io.ktor.client.plugins.ResponseException
 import io.ktor.client.request.HttpRequestBuilder
 import io.ktor.client.statement.HttpResponse
@@ -18,20 +20,33 @@ import kotlinx.serialization.SerializationException
 
 expect class UnknownHostException : Exception
 
-internal suspend inline fun <reified T> HttpClient.request(
-    block: HttpClient.() -> HttpResponse
-): Either<NetworkError, T> = try {
+/**
+ * Executes [block] on the receiver [HttpClient] exactly once and maps every known
+ * failure mode to the appropriate [DomainError] variant.
+ *
+ * This is the low-level primitive: it does NOT retry, does NOT do a connectivity
+ * pre-check, and does NOT know about backoff. Those concerns live in
+ * [ResilientHttpRequester], which calls this inside [arrow.resilience.Schedule].
+ *
+ * `CancellationException` is always rethrown so coroutine cancellation propagates
+ * correctly through the retry loop above.
+ */
+internal suspend inline fun <reified T> HttpClient.singleAttempt(
+    noinline block: HttpClient.() -> HttpResponse,
+): Either<DomainError, T> = try {
     val response = block()
     response.body<T>().right()
 } catch (e: CancellationException) {
     throw e
+} catch (e: HttpRequestTimeoutException) {
+    DomainError.Timeout(e).left()
 } catch (e: ResponseException) {
-    NetworkError.HttpError(e.response.status.value, e.response.bodyAsText()).left()
+    DomainError.HttpError(e.response.status.value, e.response.bodyAsText()).left()
 } catch (e: Throwable) {
     val networkError = when (e) {
-        is UnknownHostException, is UnresolvedAddressException, is IOException -> NetworkError.ConnectionError(e)
-        is SerializationException, is JsonConvertException -> NetworkError.SerializationError(e)
-        else -> NetworkError.UnknownError(e)
+        is UnknownHostException, is UnresolvedAddressException, is IOException -> DomainError.ConnectionError(e)
+        is SerializationException, is JsonConvertException -> DomainError.SerializationError(e)
+        else -> DomainError.UnknownError(e)
     }
     networkError.left()
 }

--- a/shared/core/network/impl/src/commonMain/kotlin/com/xbot/network/client/HttpClientExtensions.kt
+++ b/shared/core/network/impl/src/commonMain/kotlin/com/xbot/network/client/HttpClientExtensions.kt
@@ -32,7 +32,7 @@ expect class UnknownHostException : Exception
  * correctly through the retry loop above.
  */
 internal suspend inline fun <reified T> HttpClient.singleAttempt(
-    noinline block: HttpClient.() -> HttpResponse,
+    noinline block: suspend HttpClient.() -> HttpResponse,
 ): Either<DomainError, T> = try {
     val response = block()
     response.body<T>().right()

--- a/shared/core/network/impl/src/commonMain/kotlin/com/xbot/network/client/HttpClientFactory.kt
+++ b/shared/core/network/impl/src/commonMain/kotlin/com/xbot/network/client/HttpClientFactory.kt
@@ -6,6 +6,7 @@ import com.xbot.network.utils.brotli
 import io.ktor.client.HttpClient
 import io.ktor.client.plugins.ClientRequestException
 import io.ktor.client.plugins.HttpResponseValidator
+import io.ktor.client.plugins.HttpTimeout
 import io.ktor.client.plugins.auth.Auth
 import io.ktor.client.plugins.auth.providers.bearer
 import io.ktor.client.plugins.compression.ContentEncoding
@@ -44,6 +45,12 @@ internal fun createHttpClient(
             ignoreUnknownKeys = true
             coerceInputValues = true
         })
+    }
+
+    install(HttpTimeout) {
+        requestTimeoutMillis = 10_000
+        connectTimeoutMillis = 5_000
+        socketTimeoutMillis = 10_000
     }
 
     Auth {

--- a/shared/core/network/impl/src/commonMain/kotlin/com/xbot/network/client/NetworkRetryPolicy.kt
+++ b/shared/core/network/impl/src/commonMain/kotlin/com/xbot/network/client/NetworkRetryPolicy.kt
@@ -1,9 +1,6 @@
 package com.xbot.network.client
 
 import arrow.resilience.Schedule
-import arrow.resilience.and
-import arrow.resilience.doWhile
-import arrow.resilience.jittered
 import com.xbot.domain.models.DomainError
 import kotlin.time.Duration.Companion.milliseconds
 import org.koin.core.annotation.Singleton

--- a/shared/core/network/impl/src/commonMain/kotlin/com/xbot/network/client/NetworkRetryPolicy.kt
+++ b/shared/core/network/impl/src/commonMain/kotlin/com/xbot/network/client/NetworkRetryPolicy.kt
@@ -1,0 +1,34 @@
+package com.xbot.network.client
+
+import arrow.resilience.Schedule
+import arrow.resilience.and
+import arrow.resilience.doWhile
+import arrow.resilience.jittered
+import com.xbot.domain.models.DomainError
+import kotlin.time.Duration.Companion.milliseconds
+import org.koin.core.annotation.Singleton
+
+/**
+ * Default retry policy for transient network failures.
+ *
+ * **Shape:** exponential backoff starting at 200ms, factor 2, capped at 3 retries
+ * (=4 total attempts), jittered to avoid retry storms, gated by [DomainError.isRetryable]
+ * so only transient conditions (5xx, 408, 429, `Timeout`, `ConnectionError`) trigger
+ * another attempt.
+ *
+ * Worst-case total delay pre-jitter: 200 + 400 + 800 ≈ 1.4s across 3 retries.
+ * With the per-attempt 10s [io.ktor.client.plugins.HttpTimeout], an absolute worst-case
+ * transaction is roughly 43s; in practice the jitter + transient recovery makes the
+ * p50 retry path end within 300–500ms.
+ *
+ * Exposed as a Koin singleton so tests can replace it with a deterministic (no-jitter,
+ * fewer retries) variant.
+ */
+@Singleton
+internal fun networkRetrySchedule(): Schedule<DomainError, *> =
+    Schedule.exponential<DomainError>(200.milliseconds, factor = 2.0)
+        .and(Schedule.recurs(RETRIES))
+        .jittered()
+        .doWhile { error, _ -> error.isRetryable }
+
+private const val RETRIES: Long = 3

--- a/shared/core/network/impl/src/commonMain/kotlin/com/xbot/network/client/ResilientHttpRequester.kt
+++ b/shared/core/network/impl/src/commonMain/kotlin/com/xbot/network/client/ResilientHttpRequester.kt
@@ -15,10 +15,15 @@ import org.koin.core.annotation.Singleton
  *
  * Combines three resilience layers:
  *
- * 1. **Connectivity pre-flight** — if [connectivity] reports offline, we short-circuit
- *    with [DomainError.NoConnection] before touching the wire. Different UX copy and
- *    recovery path than [DomainError.ConnectionError] (which comes from a failed
- *    socket).
+ * 1. **Per-attempt connectivity gate** — every retry tick checks
+ *    [ConnectivityMonitor.isOnline] first; if offline we short-circuit with
+ *    [DomainError.NoConnection] before touching the wire. Doing the check per-attempt
+ *    (not just once before the loop) means a connection dropped mid-backoff surfaces
+ *    as NoConnection on the very next tick, rather than burning the remaining retry
+ *    budget on doomed [DomainError.ConnectionError]s. NoConnection is non-retryable,
+ *    so the Schedule exits cleanly on first offline tick. Distinct from
+ *    [DomainError.ConnectionError] (which comes from a socket that actually attempted
+ *    a connection) — different UX copy, different recovery path.
  * 2. **Per-attempt timeout** — bounded by the [io.ktor.client.plugins.HttpTimeout]
  *    plugin installed on the underlying [client]; hung sockets surface as
  *    [DomainError.Timeout].
@@ -40,8 +45,11 @@ internal class ResilientHttpRequester(
      */
     suspend inline fun <reified T> request(
         noinline block: suspend HttpClient.() -> HttpResponse,
-    ): Either<DomainError, T> {
-        if (!connectivity.isOnline()) return DomainError.NoConnection.left()
-        return schedule.retryEither { client.singleAttempt<T>(block) }
+    ): Either<DomainError, T> = schedule.retryEither {
+        if (!connectivity.isOnline()) {
+            DomainError.NoConnection.left()
+        } else {
+            client.singleAttempt<T>(block)
+        }
     }
 }

--- a/shared/core/network/impl/src/commonMain/kotlin/com/xbot/network/client/ResilientHttpRequester.kt
+++ b/shared/core/network/impl/src/commonMain/kotlin/com/xbot/network/client/ResilientHttpRequester.kt
@@ -39,7 +39,7 @@ internal class ResilientHttpRequester(
      * is expressed as [Either.Left] of the matching [DomainError] variant. No throw.
      */
     suspend inline fun <reified T> request(
-        noinline block: HttpClient.() -> HttpResponse,
+        noinline block: suspend HttpClient.() -> HttpResponse,
     ): Either<DomainError, T> {
         if (!connectivity.isOnline()) return DomainError.NoConnection.left()
         return schedule.retryEither { client.singleAttempt<T>(block) }

--- a/shared/core/network/impl/src/commonMain/kotlin/com/xbot/network/client/ResilientHttpRequester.kt
+++ b/shared/core/network/impl/src/commonMain/kotlin/com/xbot/network/client/ResilientHttpRequester.kt
@@ -1,0 +1,47 @@
+package com.xbot.network.client
+
+import arrow.core.Either
+import arrow.core.left
+import arrow.resilience.Schedule
+import arrow.resilience.retryEither
+import com.xbot.domain.models.DomainError
+import com.xbot.network.connectivity.ConnectivityMonitor
+import io.ktor.client.HttpClient
+import io.ktor.client.statement.HttpResponse
+import org.koin.core.annotation.Singleton
+
+/**
+ * Central entry point for every HTTP call in the app.
+ *
+ * Combines three resilience layers:
+ *
+ * 1. **Connectivity pre-flight** — if [connectivity] reports offline, we short-circuit
+ *    with [DomainError.NoConnection] before touching the wire. Different UX copy and
+ *    recovery path than [DomainError.ConnectionError] (which comes from a failed
+ *    socket).
+ * 2. **Per-attempt timeout** — bounded by the [io.ktor.client.plugins.HttpTimeout]
+ *    plugin installed on the underlying [client]; hung sockets surface as
+ *    [DomainError.Timeout].
+ * 3. **Typed retries** — [schedule] drives exponential-with-jitter backoff and uses
+ *    [DomainError.isRetryable] as the gate. Auth errors (401/403) are NOT retryable
+ *    here, so we don't fight the Ktor Auth plugin's refresh flow.
+ */
+@Singleton
+internal class ResilientHttpRequester(
+    private val client: HttpClient,
+    private val connectivity: ConnectivityMonitor,
+    private val schedule: Schedule<DomainError, *>,
+) {
+    /**
+     * Execute [block] on the underlying [HttpClient] and decode the response as [T].
+     *
+     * Every failure mode — network hiccup, 5xx, body parse error, timeout, offline —
+     * is expressed as [Either.Left] of the matching [DomainError] variant. No throw.
+     */
+    suspend inline fun <reified T> request(
+        noinline block: HttpClient.() -> HttpResponse,
+    ): Either<DomainError, T> {
+        if (!connectivity.isOnline()) return DomainError.NoConnection.left()
+        return schedule.retryEither { client.singleAttempt<T>(block) }
+    }
+}

--- a/shared/core/network/impl/src/iosMain/kotlin/com/xbot/network/connectivity/IosConnectivityMonitor.kt
+++ b/shared/core/network/impl/src/iosMain/kotlin/com/xbot/network/connectivity/IosConnectivityMonitor.kt
@@ -1,0 +1,53 @@
+package com.xbot.network.connectivity
+
+import kotlinx.cinterop.ExperimentalForeignApi
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import org.koin.core.annotation.Singleton
+import platform.Network.nw_path_get_status
+import platform.Network.nw_path_monitor_cancel
+import platform.Network.nw_path_monitor_create
+import platform.Network.nw_path_monitor_set_queue
+import platform.Network.nw_path_monitor_set_update_handler
+import platform.Network.nw_path_monitor_start
+import platform.Network.nw_path_monitor_t
+import platform.Network.nw_path_status_satisfied
+import platform.darwin.dispatch_get_global_queue
+import platform.darwin.DISPATCH_QUEUE_PRIORITY_DEFAULT
+
+/**
+ * iOS connectivity monitor backed by `NWPathMonitor` (Network framework).
+ *
+ * Starts in `init` and runs for the lifetime of the singleton (app-lifetime). The
+ * monitor updates a [MutableStateFlow] so [currentState] stays cheap for use as a
+ * pre-flight check in the HTTP layer.
+ */
+@OptIn(ExperimentalForeignApi::class)
+@Singleton
+internal class IosConnectivityMonitor : ConnectivityMonitor {
+
+    private val state = MutableStateFlow(ConnectivityState.Available)
+
+    private val monitor: nw_path_monitor_t = nw_path_monitor_create()
+
+    init {
+        nw_path_monitor_set_update_handler(monitor) { path ->
+            state.value = if (nw_path_get_status(path) == nw_path_status_satisfied) {
+                ConnectivityState.Available
+            } else {
+                ConnectivityState.Unavailable
+            }
+        }
+        nw_path_monitor_set_queue(
+            monitor,
+            dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT.toLong(), 0u),
+        )
+        nw_path_monitor_start(monitor)
+    }
+
+    override val currentState: ConnectivityState
+        get() = state.value
+
+    override fun observe(): Flow<ConnectivityState> = state.asStateFlow()
+}

--- a/shared/core/network/impl/src/jvmMain/kotlin/com/xbot/network/connectivity/JvmConnectivityMonitor.kt
+++ b/shared/core/network/impl/src/jvmMain/kotlin/com/xbot/network/connectivity/JvmConnectivityMonitor.kt
@@ -1,0 +1,25 @@
+package com.xbot.network.connectivity
+
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import org.koin.core.annotation.Singleton
+
+/**
+ * JVM/desktop connectivity stub.
+ *
+ * Plain JVM environments are too varied for a reliable cheap reachability check
+ * (corporate proxies, VPNs, captive portals, chroot jails). The stub reports
+ * [ConnectivityState.Available] unconditionally — the resilience layer will surface
+ * real failures via `ConnectionError` / `Timeout` and their retry policies rather than
+ * gate on a pessimistic local guess.
+ */
+@Singleton
+internal class JvmConnectivityMonitor : ConnectivityMonitor {
+    private val state = MutableStateFlow(ConnectivityState.Available)
+
+    override val currentState: ConnectivityState
+        get() = state.value
+
+    override fun observe(): Flow<ConnectivityState> = state.asStateFlow()
+}


### PR DESCRIPTION
## Summary

- Replaces single-shot `HttpClient.request` with `ResilientHttpRequester`: connectivity pre-check + Arrow `Schedule` exponential retry with jitter + Ktor `HttpTimeout` per-attempt timeout.
- Collapses `NetworkError` and `DomainError` into a single hierarchy in `:domain:api` — adds `Timeout` and `NoConnection` variants plus an `isRetryable` predicate consumed by the retry `Schedule`.
- Makes Paging3 Arrow-native: `CommonPagingSource` speaks `Either<DomainError, T>` internally and folds at the `LoadResult` boundary. Since `DomainError : Exception`, `LoadResult.Error` works without a wrapper. No more `throw it.toDomain()` inside paging lambdas.
- Adds `ConnectivityMonitor` with `expect`/`actual` implementations: Android `NetworkCallback` + `NET_CAPABILITY_VALIDATED`, iOS `nw_path_monitor`, JVM always-`Available` stub.
- Extends `AsyncResult` with `Either.toAsyncResult()` bridge and `fold` / `onSuccess` / `onError` / `onLoading` helpers.

## Design notes

### Why `NoConnection` is distinct from `ConnectionError`

- `ConnectionError` = IOException/UnknownHostException from the socket — request was attempted.
- `NoConnection` = connectivity monitor says offline — nothing hit the wire. Different UX copy; `NoConnection` intentionally NOT retryable (gated before the request fires; reconnection is a separate concern via `ConnectivityMonitor.observe()`).

### Retry policy

`Schedule.exponential(200ms, factor = 2.0).and(Schedule.recurs(3)).jittered().doWhile { it.isRetryable }`.
Worst case: ~3.4s pre-jitter across 3 retries. Combined with 10s per-attempt timeout, absolute worst case ~43s before surfacing error.

`isRetryable` gates:
- `ConnectionError`, `Timeout` → retry
- `HttpError` → retry iff code in 500..599 or 408/429
- `SerializationError`, `UnknownError`, `NoConnection` → do not retry

401 is NOT in the retry set — Auth plugin's refresh flow stays untouched.

### Paging3 × Arrow

`DomainError` extends `Exception`, so `LoadResult.Error(domainError)` satisfies the `Throwable` contract directly. Read-side code (e.g., `loadState.refresh as? LoadState.Error`) gets a typed `DomainError` back with no downcast dance.

## Test plan

- [ ] Android: happy path across Home feed, Catalog (paged), Title details, Login, Favorites
- [ ] Android: airplane mode mid-session → next API call surfaces `NoConnection` banner; reconnect → recovery on next request
- [ ] Android: throttle to 300ms RTT via dev options → no extra retries on happy path
- [ ] iOS simulator: Network Link Conditioner "100% Loss" → `NoConnection`; "3G" → works with some retry variance
- [ ] Desktop (JVM): no regressions (monitor stubbed)
- [ ] Gradle: `./gradlew :android-app:assembleDebug :jvm-app:build :shared:core:network:impl:build` green

## Follow-ups (separate PRs, not in this one)

1. Rename `DomainError` → `AppError` into a new leaf module `:shared:core:result` (eliminates `:network:api → :domain:api` dep smell)
2. Redesign `asyncLoad`: drop bifurcated `onError` param, always persist error in state; add typed `Reload*` actions for per-section retry
3. Two-tier UI errors: derived `screenHealth` in state for screen-level overlay (no connection / all slots fail); per-section inline error rendering for partial failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)